### PR TITLE
Fix statistics display on rtt is less than 1 ms

### DIFF
--- a/tcping.go
+++ b/tcping.go
@@ -161,7 +161,7 @@ func findMinAvgMaxRttTime(timeArr []uint) rttResults {
 		}
 	}
 
-	if accum != 0 {
+	if arrLen > 0 {
 		rttResults.hasResults = true
 		rttResults.average = float32(accum) / float32(arrLen)
 	}


### PR DESCRIPTION
Related to #10 

* Just changed the hasResults condition.

Slowest, fastest and average are displayed as 0ms.
That means those values are less than 1 ms.

<img src="https://user-images.githubusercontent.com/89819001/169436005-c0897bb1-0a01-48c0-9db1-ca5996c8d289.png" width="600px">