### PR TITLE
Add -r option to retry resolving target's hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,13 +56,13 @@ sudo cp tcping /usr/bin/
 Then run it like, `tcping <hostname/IP address> <port>`. For instance:
 
 ```bash
-tcping www.example.com -p 443
+tcping www.example.com 443
 ```
 
 OR
 
 ```bash
-tcping 10.10.10.1 -p 22
+tcping 10.10.10.1 22
 ```
 
 ### On ```Windows```
@@ -74,13 +74,13 @@ For easier use, copy ```tcping.exe``` to your system ```PATH``` like C:\Windows\
 Run it like:
 
 ```powershell
-tcping www.example.com -p 443
+tcping www.example.com 443
 ```
 
 OR
 
 ```powershell
-.\tcping.exe 10.10.10.1 -p 22
+.\tcping.exe 10.10.10.1 22
 ```
 
 **Please note, if you copy the program to your system ```PATH```, you don't need to specify ```.\``` and the `.exe` extension to run the program anymore.**

--- a/README.md
+++ b/README.md
@@ -56,13 +56,13 @@ sudo cp tcping /usr/bin/
 Then run it like, `tcping <hostname/IP address> <port>`. For instance:
 
 ```bash
-tcping www.example.com 443
+tcping www.example.com -p 443
 ```
 
 OR
 
 ```bash
-tcping 10.10.10.1 22
+tcping 10.10.10.1 -p 22
 ```
 
 ### On ```Windows```
@@ -74,13 +74,13 @@ For easier use, copy ```tcping.exe``` to your system ```PATH``` like C:\Windows\
 Run it like:
 
 ```powershell
-tcping www.example.com 443
+tcping www.example.com -p 443
 ```
 
 OR
 
 ```powershell
-.\tcping.exe 10.10.10.1 22
+.\tcping.exe 10.10.10.1 -p 22
 ```
 
 **Please note, if you copy the program to your system ```PATH```, you don't need to specify ```.\``` and the `.exe` extension to run the program anymore.**

--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,6 @@ go 1.16
 
 require (
 	github.com/gookit/color v1.4.2
+	github.com/stretchr/testify v1.7.1 // indirect
 	golang.org/x/sys v0.0.0-20210819135213-f52c844e1c1c // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778 h1:QldyIu/L63oPpyvQmHgvgickp1Yw510KJOqX7H24mg8=
 github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778/go.mod h1:2MuV+tbUrU1zIOPMxZ5EncGwgmMJsa+9ucAQZXxsObs=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/tcping.go
+++ b/tcping.go
@@ -75,9 +75,9 @@ func usage() {
 	color.Red.Printf("Try running %s like:\n", flag.CommandLine.Name())
 	color.Red.Printf("%s <hostname/ip> <port number> | for example:\n", flag.CommandLine.Name())
 	color.Red.Printf("%s www.example.com 443\n", flag.CommandLine.Name())
-	color.Red.Print("[option]\n")
+	color.Red.Print("[optional]\n")
 	flag.VisitAll(func(f *flag.Flag) {
-		color.Red.Printf("  %s : %s\n", f.Name, f.Usage)
+		color.Red.Printf("  -%s : %s\n", f.Name, f.Usage)
 	})
 	os.Exit(1)
 }

--- a/tcping.go
+++ b/tcping.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strconv"
 	"syscall"
 	"time"
@@ -72,9 +73,11 @@ var (
 
 /* Print how program should be run */
 func usage() {
-	color.Red.Printf("Try running %s like:\n", flag.CommandLine.Name())
-	color.Red.Printf("%s <hostname/ip> <port number> | for example:\n", flag.CommandLine.Name())
-	color.Red.Printf("%s www.example.com 443\n", flag.CommandLine.Name())
+	/* flag.CommandLine.Name() is also included in the directory path in some cases, such as 'go run tcping.go' */
+	var commandName = filepath.Base(flag.CommandLine.Name())
+	color.Red.Printf("Try running %s like:\n", commandName)
+	color.Red.Printf("%s <hostname/ip> <port number> | for example:\n", commandName)
+	color.Red.Printf("%s www.example.com 443\n", commandName)
 	color.Red.Print("[optional]\n")
 	flag.VisitAll(func(f *flag.Flag) {
 		color.Red.Printf("  -%s : %s\n", f.Name, f.Usage)

--- a/tcping.go
+++ b/tcping.go
@@ -70,8 +70,8 @@ var (
 /* Print how program should be run */
 func usage() {
 	color.Red.Printf("Try running %s like:\n", flag.CommandLine.Name())
-	color.Red.Printf("%s <hostname/ip> -p <port number> | for example:\n", flag.CommandLine.Name())
-	color.Red.Printf("%s www.example.com -p 443\n", flag.CommandLine.Name())
+	color.Red.Printf("%s <hostname/ip> <port number> | for example:\n", flag.CommandLine.Name())
+	color.Red.Printf("%s www.example.com 443\n", flag.CommandLine.Name())
 	os.Exit(1)
 }
 
@@ -91,29 +91,28 @@ func signalHandler(tcpStats *stats) {
 /* Get and validate user input */
 func getInput() (string, string, string) {
 	flag.CommandLine.Usage = usage
-	pPtr := flag.Int("p", 80, "port")
 	permuteArgs(os.Args[1:])
 	flag.Parse()
 
 	/* the non-flag command-line arguments */
 	args := flag.Args()
 
-	if len(args) != 1 {
+	if len(args) != 2 {
 		usage()
 	}
 
 	host := args[0]
-	port := *pPtr
+	port := args[1]
+	portInt, _ := strconv.Atoi(port)
 
-	if port < 1 || port > 65535 {
+	if portInt < 1 || portInt > 65535 {
 		print("Port should be in 1..65535 range\n")
 		os.Exit(1)
 	}
 
-	portStr := strconv.Itoa(port)
 	IP := resolveHostname(host)
 
-	return host, portStr, IP
+	return host, port, IP
 }
 
 /* Permute args for flag parsing stops just before the first non-flag argument. */
@@ -127,9 +126,6 @@ func permuteArgs(args []string) {
 		if v[0] == '-' {
 			optionName := v[1:]
 			switch optionName {
-			case "p":
-				flagArgs = append(flagArgs, args[i:i+2]...)
-				i++
 			default:
 				flagArgs = append(flagArgs, args[i])
 			}

--- a/tcping.go
+++ b/tcping.go
@@ -32,8 +32,10 @@ type stats struct {
 	totalDowntime         time.Duration
 	totalSuccessfulPkts   uint
 	totalUnsuccessfulPkts uint
+	lastUnsuccessfulPkts  uint
 	wasDown               bool // Used to determine the duration of a downtime
 	isIP                  bool // If IP is provided instead of hostname, suppresses printing the IP information twice
+	shouldRetryResolve    bool // Retry resolving target's hostname after a certain number of failed requests
 }
 
 type longestTime struct {
@@ -50,11 +52,12 @@ type rttResults struct {
 }
 
 const (
-	ThousandMilliSecond = 1000 * time.Millisecond
-	oneSecond           = 1 * time.Second
-	timeFormat          = "2006-01-02 15:04:05"
-	nullTimeFormat      = "0001-01-01 00:00:00"
-	hourFormat          = "15:04:05"
+	ThousandMilliSecond   = 1000 * time.Millisecond
+	oneSecond             = 1 * time.Second
+	timeFormat            = "2006-01-02 15:04:05"
+	nullTimeFormat        = "0001-01-01 00:00:00"
+	hourFormat            = "15:04:05"
+	retryResolveThreshold = 10
 )
 
 var (
@@ -72,6 +75,10 @@ func usage() {
 	color.Red.Printf("Try running %s like:\n", flag.CommandLine.Name())
 	color.Red.Printf("%s <hostname/ip> <port number> | for example:\n", flag.CommandLine.Name())
 	color.Red.Printf("%s www.example.com 443\n", flag.CommandLine.Name())
+	color.Red.Print("[option]\n")
+	flag.VisitAll(func(f *flag.Flag) {
+		color.Red.Printf("  %s : %s\n", f.Name, f.Usage)
+	})
 	os.Exit(1)
 }
 
@@ -89,9 +96,10 @@ func signalHandler(tcpStats *stats) {
 }
 
 /* Get and validate user input */
-func getInput() (string, string, string) {
-	flag.CommandLine.Usage = usage
+func getInput() (string, string, string, bool) {
 	permuteArgs(os.Args[1:])
+	shouldRetryResolve := flag.Bool("r", false, "retry resolving target's hostname after a certain number of failed requests.")
+	flag.CommandLine.Usage = usage
 	flag.Parse()
 
 	/* the non-flag command-line arguments */
@@ -112,7 +120,7 @@ func getInput() (string, string, string) {
 
 	IP := resolveHostname(host)
 
-	return host, port, IP
+	return host, port, IP, *shouldRetryResolve
 }
 
 /* Permute args for flag parsing stops just before the first non-flag argument. */
@@ -162,6 +170,20 @@ func resolveHostname(host string) string {
 	IP = IPaddr[0].String()
 
 	return IP
+}
+
+/* Retry resolve hostname */
+func retryResolve(tcpStats *stats) {
+	if tcpStats.isIP {
+		return
+	}
+	if tcpStats.lastUnsuccessfulPkts < retryResolveThreshold {
+		return
+	}
+
+	colorYellow("Retry resolve %s\n", tcpStats.hostname)
+	tcpStats.IP = resolveHostname(tcpStats.hostname)
+	tcpStats.lastUnsuccessfulPkts = 0
 }
 
 /* Create LongestTime structure */
@@ -479,6 +501,7 @@ func tcping(tcpStats *stats) {
 		tcpStats.totalDowntime += time.Second
 		tcpStats.totalUnsuccessfulPkts += 1
 		tcpStats.lastUnsuccessfulProbe = getSystemTime()
+		tcpStats.lastUnsuccessfulPkts += 1
 
 		printReply(tcpStats, "No reply", 0)
 	} else {
@@ -500,6 +523,7 @@ func tcping(tcpStats *stats) {
 			tcpStats.startOfDowntime = time.Time{}
 
 			tcpStats.wasDown = false
+			tcpStats.lastUnsuccessfulPkts = 0
 		}
 
 		/* It means it is the first time to get a response*/
@@ -531,12 +555,13 @@ func monitorStdin(stdinChan chan string) {
 
 func main() {
 
-	host, port, IP := getInput()
+	host, port, IP, shouldRetryResolve := getInput()
 
 	var tcpStats stats
 	tcpStats.hostname = host
 	tcpStats.IP = IP
 	tcpStats.port = port
+	tcpStats.shouldRetryResolve = shouldRetryResolve
 	tcpStats.startTime = getSystemTime()
 
 	if host == IP {
@@ -551,6 +576,9 @@ func main() {
 	go monitorStdin(stdinChan)
 
 	for {
+		if tcpStats.shouldRetryResolve {
+			retryResolve(&tcpStats)
+		}
 		tcping(&tcpStats)
 
 		/* print stats when the `enter` key is pressed */

--- a/tcping_test.go
+++ b/tcping_test.go
@@ -1,6 +1,9 @@
 package main
 
-import "testing"
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
 
 func TestCalcTime(t *testing.T) {
 	type args struct {
@@ -67,6 +70,34 @@ func TestCalcTime(t *testing.T) {
 			if got := calcTime(tt.args.time); got != tt.want {
 				t.Errorf("calcTime() = %v, want %v", got, tt.want)
 			}
+		})
+	}
+}
+
+func TestPermuteArgs(t *testing.T) {
+	type args struct {
+		args []string
+	}
+	tests := []struct {
+		name string
+		args args
+		want []string
+	}{
+		{
+			"host/ip before option",
+			args{args: []string{"127.0.0.1", "-p", "8080"}},
+			[]string{"-p", "8080", "127.0.0.1"},
+		},
+		{
+			"host/ip after option",
+			args{args: []string{"-p", "8080", "127.0.0.1"}},
+			[]string{"-p", "8080", "127.0.0.1"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			permuteArgs(tt.args.args)
+			assert.Equal(t, tt.want, tt.args.args)
 		})
 	}
 }

--- a/tcping_test.go
+++ b/tcping_test.go
@@ -85,13 +85,13 @@ func TestPermuteArgs(t *testing.T) {
 	}{
 		{
 			"host/ip before option",
-			args{args: []string{"127.0.0.1", "-p", "8080"}},
-			[]string{"-p", "8080", "127.0.0.1"},
+			args{args: []string{"127.0.0.1", "8080", "-r"}},
+			[]string{"-r", "127.0.0.1", "8080"},
 		},
 		{
 			"host/ip after option",
-			args{args: []string{"-p", "8080", "127.0.0.1"}},
-			[]string{"-p", "8080", "127.0.0.1"},
+			args{args: []string{"-r", "127.0.0.1", "8080"}},
+			[]string{"-r", "127.0.0.1", "8080"},
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Related to #4 
(only replace with flag package)

* Add tests.
* Add usage option to READ.ME.

**PermuteArgs** can be confusing.
Flag parsing stops just before the first non-flag argument in [flag package](https://pkg.go.dev/flag#:~:text=Flag%20parsing%20stops%20just%20before%20the%20first%20non%2Dflag%20argument%20(%22%2D%22%20is%20a%20non%2Dflag%20argument)%20or%20after%20the%20terminator%20%22%2D%2D%22.).
So, **permuteArgs** keeps the sequence uniform.

ex)
`tcping 127.0.0.1 -p 8080`
↓
`tcping -p 8080 127.0.0.1`

Please review, before I add flag to retry resolving target's hostname.