### PR TITLE
Provide a flag to check for newer versions

### DIFF
--- a/tcping.go
+++ b/tcping.go
@@ -218,7 +218,7 @@ func checkLatestVersion() {
 		colorLightBlue("Please update TCPING from the URL below:\n")
 		colorLightBlue("https://github.com/%s/%s/releases/tag/%s\n", owner, repo, latestTagName)
 	} else {
-		colorLightBlue("Not found newer version. Your version %s is latest.\n", version)
+		colorLightBlue("Newer version not found . Your version %s is the latest.\n", version)
 	}
 	os.Exit(0)
 }

--- a/tcping.go
+++ b/tcping.go
@@ -110,7 +110,7 @@ func signalHandler(tcpStats *stats) {
 /* Get and validate user input */
 func processUserInput(tcpStats *stats) {
 	tcpStats.retryHostnameResolveAfter = flag.Uint("r", 0, "retry resolving target's hostname after <n> number of failed requests. e.g. -r 10 for 10 failed probes")
-	shouldCheckUpdates := flag.Bool("u", false, "check for updates and display a message if there is a newer version. it works on its own.")
+	shouldCheckUpdates := flag.Bool("u", false, "check for updates.")
 	flag.CommandLine.Usage = usage
 	permuteArgs(os.Args[1:])
 	flag.Parse()

--- a/tcping_test.go
+++ b/tcping_test.go
@@ -80,54 +80,33 @@ func TestPermuteArgs(t *testing.T) {
 		args []string
 	}
 	tests := []struct {
-		name    string
-		args    args
-		want    []string
-		wantErr error
+		name string
+		args args
+		want []string
 	}{
 		{
 			"host/ip before option",
-			args{args: []string{"127.0.0.1", "8080", "-r", "3", "-u"}},
-			[]string{"-r", "3", "-u", "127.0.0.1", "8080"},
-			nil,
+			args{args: []string{"127.0.0.1", "8080", "-r", "3"}},
+			[]string{"-r", "3", "127.0.0.1", "8080"},
 		},
 		{
 			"host/ip after option",
-			args{args: []string{"-r", "3", "-u", "127.0.0.1", "8080"}},
-			[]string{"-r", "3", "-u", "127.0.0.1", "8080"},
-			nil,
+			args{args: []string{"-r", "3", "127.0.0.1", "8080"}},
+			[]string{"-r", "3", "127.0.0.1", "8080"},
 		},
 		{
-			"args not enough",
-			args{args: []string{"-r", "3", "-u", "127.0.0.1"}},
-			[]string{"-r", "3", "-u", "127.0.0.1"},
-			errArgsNotEnough,
+			"check for updates",
+			args{args: []string{"-u"}},
+			[]string{"-u"},
 		},
-		{
-			"args not enough. it means that the 8080 was interpreted as the value of -r",
-			args{args: []string{"-u", "127.0.0.1", "-r", "8080"}},
-			[]string{"-u", "127.0.0.1", "-r", "8080"},
-			errArgsNotEnough,
-		},
-		{
-			"flag has no value. the next flag has come",
-			args{args: []string{"-r", "-u", "127.0.0.1", "8080"}},
-			[]string{"-r", "-u", "127.0.0.1", "8080"},
-			errArgsFlagHasNoValue,
-		},
-		{
-			"flag has no value. out of index",
-			args{args: []string{"-u", "127.0.0.1", "8080", "-r"}},
-			[]string{"-u", "127.0.0.1", "8080", "-r"},
-			errArgsFlagHasNoValue,
-		},
+		/**
+		 * cases in which the value of the option does not exist are not listed.
+		 * they call directly usage() and exit with code 1.
+		 */
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := permuteArgs(tt.args.args)
-			if tt.wantErr != nil {
-				assert.EqualError(t, err, tt.wantErr.Error())
-			}
+			permuteArgs(tt.args.args)
 			assert.Equal(t, tt.want, tt.args.args)
 		})
 	}


### PR DESCRIPTION
Related to #15 

There are a few things to check.

* I have added error cases (errArgsFlagHasNoValue, errArgsNotEnough) for testing purposes, but is it subtle to define errors that are not actually used?

* I included **checkLatestVersion()** in **processUserInput(tcpStats *stats)**.
This is because if there is some other error after parse, the user will not get to the update display.
But it seems a bit odd in logic.

Please review.