### PR TITLE
refactor: nanoToMillisecond function

### DIFF
--- a/tcping.go
+++ b/tcping.go
@@ -481,8 +481,11 @@ func calcLongestDowntime(tcpStats *stats, duration time.Duration) {
 	}
 }
 
+// nanoToMillisecond returns an amount of milliseconds from nanoseconds.
+// Using duration.Milliseconds() is not an option, because it drops
+// decimal points, returning an int.
 func nanoToMillisecond(nano int64) float32 {
-	return float32(nano) / 1e6
+	return float32(nano) / float32(time.Millisecond)
 }
 
 func (tcpStats *stats) handleConnError(now time.Time) {

--- a/tcping_test.go
+++ b/tcping_test.go
@@ -109,3 +109,24 @@ func TestPermuteArgs(t *testing.T) {
 		})
 	}
 }
+
+func TestNanoToMilliseconds(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		d    time.Duration
+		want float32
+	}{
+		{d: time.Millisecond, want: 1},
+		{d: 100*time.Millisecond + 123*time.Nanosecond, want: 100.000123},
+		{d: time.Second, want: 1000},
+		{d: time.Second + 100*time.Nanosecond, want: 1000.000123},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.d.String(), func(t *testing.T) {
+			t.Parallel()
+			got := nanoToMillisecond(tt.d.Nanoseconds())
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
## Describe your changes

Removed magic `1e6`, replaced it by `time.Millisecond`, which is a lot readable.

At first, I wanted to remove that function and just replace it with `duration.Milliseconds()`, but that (for some reason) drops decimal points (returns int64, not float64 like `.Seconds()` or `.Hours()`). So, I also added a comment explaining why that function should be used.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have run `make check` and there are no failures.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
