### PR TITLE
feat: add `c` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ The following flags are available to control the behavior of application:
 | `-4`       | Only use IPv4 addresses                                   |
 | `-6`       | Only use IPv6 addresses                                   |
 | `-r`       | Retry resolving a hostname after `<n>` number of failures |
-| `-c`       | Ping `<n>` amount of times, regardless of the result      |
+| `-c`       | Ping `<n>` amount of times, regardless of the result  (available from version 1.23)    |
 | `-j`       | Output in JSON format                                     |
 | `--pretty` | Prettify the JSON output                                  |
 | `-v`       | Print version                                             |

--- a/README.md
+++ b/README.md
@@ -218,14 +218,15 @@ docker run -it ghcr.io/pouriyajamshidi/tcping:latest example.com 443
 The following flags are available to control the behavior of application:
 
 | Flag       | Description                                               |
-| ---------- | --------------------------------------------------------- |
-| `-r`       | Retry resolving a hostname after `<n>` number of failures |
+|------------|-----------------------------------------------------------|
 | `-4`       | Only use IPv4 addresses                                   |
 | `-6`       | Only use IPv6 addresses                                   |
+| `-r`       | Retry resolving a hostname after `<n>` number of failures |
+| `-c`       | Ping `<n>` amount of times, regardless of the result      |
 | `-j`       | Output in JSON format                                     |
 | `--pretty` | Prettify the JSON output                                  |
-| `-u`       | Check for updates                                         |
 | `-v`       | Print version                                             |
+| `-u`       | Check for updates                                         |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -217,16 +217,16 @@ docker run -it ghcr.io/pouriyajamshidi/tcping:latest example.com 443
 
 The following flags are available to control the behavior of application:
 
-| Flag       | Description                                               |
-|------------|-----------------------------------------------------------|
-| `-4`       | Only use IPv4 addresses                                   |
-| `-6`       | Only use IPv6 addresses                                   |
-| `-r`       | Retry resolving a hostname after `<n>` number of failures |
-| `-c`       | Ping `<n>` amount of times, regardless of the result  (available from version 1.23)    |
-| `-j`       | Output in JSON format                                     |
-| `--pretty` | Prettify the JSON output                                  |
-| `-v`       | Print version                                             |
-| `-u`       | Check for updates                                         |
+| Flag       | Description                                                                          |
+|------------|--------------------------------------------------------------------------------------|
+| `-4`       | Only use IPv4 addresses                                                              |
+| `-6`       | Only use IPv6 addresses                                                              |
+| `-r`       | Retry resolving a hostname after `<n>` number of failures                            |
+| `-c`       | Ping `<n>` amount of times, regardless of the result  (available from version v1.23) |
+| `-j`       | Output in JSON format                                                                |
+| `--pretty` | Prettify the JSON output                                                             |
+| `-v`       | Print version                                                                        |
+| `-u`       | Check for updates                                                                    |
 
 ---
 

--- a/tcping.go
+++ b/tcping.go
@@ -46,6 +46,7 @@ type stats struct {
 	shouldRetryResolve        bool
 	useIPv4                   bool
 	useIPv6                   bool
+	probesBeforeQuit          uint
 
 	// ticker is used to handle time between probes.
 	ticker *time.Ticker
@@ -119,13 +120,14 @@ func usage() {
 
 /* Get and validate user input */
 func processUserInput(tcpStats *stats) {
+	useIPv4 := flag.Bool("4", false, "use IPv4 only.")
+	useIPv6 := flag.Bool("6", false, "use IPv6 only.")
 	retryHostnameResolveAfter := flag.Uint("r", 0, "retry resolving target's hostname after <n> number of failed requests. e.g. -r 10 for 10 failed probes.")
-	shouldCheckUpdates := flag.Bool("u", false, "check for updates.")
+	probesBeforeQuit := flag.Uint("c", 0, "do n probes and quit, regardless of the result. If c is 0 (default), no limit will be applied")
 	outputJson := flag.Bool("j", false, "output in JSON format.")
 	prettyJson := flag.Bool("pretty", false, "use indentation when using json output format. No effect without the -j flag.")
 	showVersion := flag.Bool("v", false, "show version.")
-	useIPv4 := flag.Bool("4", false, "use IPv4 only.")
-	useIPv6 := flag.Bool("6", false, "use IPv6 only.")
+	shouldCheckUpdates := flag.Bool("u", false, "check for updates.")
 
 	flag.CommandLine.Usage = usage
 
@@ -198,6 +200,7 @@ func processUserInput(tcpStats *stats) {
 	tcpStats.port = uint16(port)
 	tcpStats.ip = resolveHostname(tcpStats)
 	tcpStats.startTime = time.Now()
+	tcpStats.probesBeforeQuit = *probesBeforeQuit
 
 	if tcpStats.hostname == tcpStats.ip.String() {
 		tcpStats.isIP = true
@@ -229,6 +232,8 @@ func permuteArgs(args cliArgs) {
 		if v[0] == '-' {
 			optionName := v[1:]
 			switch optionName {
+			case "c":
+				fallthrough
 			case "r":
 				/* out of index */
 				if len(args) <= i+1 {
@@ -571,6 +576,7 @@ func main() {
 	stdinChan := make(chan string)
 	go monitorStdin(stdinChan)
 
+	var probeCount uint = 0
 	for {
 		if tcpStats.shouldRetryResolve {
 			retryResolve(tcpStats)
@@ -585,7 +591,16 @@ func main() {
 				tcpStats.printStatistics()
 			}
 		default:
+		}
+
+		if tcpStats.probesBeforeQuit == 0 {
 			continue
+		}
+
+		probeCount++
+		if probeCount == tcpStats.probesBeforeQuit {
+			tcpStats.printStatistics()
+			return
 		}
 	}
 }


### PR DESCRIPTION
## Describe your changes
Add `-c` flag

Edge cases:
1. `-c` is uint, any negative number will fallback to `usage()`
2. `-c 0` = default behaviour, no limits
3. `-r 2 -c 3` will quit after exactly 3 probes (probe -> probe -> resolve -> probe -> quit) 

## Issue ticket number and link

Closes #72 

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added tests.
- [x] I have run `make check` and there are no failures.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update
