### PR TITLE
feat: report hostname changes

### DIFF
--- a/statsprinter.go
+++ b/statsprinter.go
@@ -115,8 +115,9 @@ func (p *planePrinter) printStatistics(s stats) {
 		colorYellow("times\n")
 
 		if len(s.hostnameChanges) >= 2 {
+			colorYellow("IP address changes:\n")
 			for i := 0; i < len(s.hostnameChanges)-1; i++ {
-				colorYellow("IP address changed from ")
+				colorYellow("  from ")
 				colorRed(s.hostnameChanges[i].Addr.String())
 				colorYellow(" to ")
 				colorGreen(s.hostnameChanges[i+1].Addr.String())

--- a/statsprinter.go
+++ b/statsprinter.go
@@ -117,11 +117,11 @@ func (p *planePrinter) printStatistics(s stats) {
 		if len(s.hostnameChanges) >= 2 {
 			for i := 0; i < len(s.hostnameChanges)-1; i++ {
 				colorYellow("IP address changed from ")
-				colorRed(s.hostnameChanges[i].addr.String())
+				colorRed(s.hostnameChanges[i].Addr.String())
 				colorYellow(" to ")
-				colorGreen(s.hostnameChanges[i+1].addr.String())
+				colorGreen(s.hostnameChanges[i+1].Addr.String())
 				colorYellow(" at ")
-				colorLightBlue("%v\n", s.hostnameChanges[i+1].when.Format(timeFormat))
+				colorLightBlue("%v\n", s.hostnameChanges[i+1].When.Format(timeFormat))
 			}
 		}
 	}
@@ -251,11 +251,12 @@ type JSONData struct {
 
 	// Optional fields below
 
-	Addr                 string `json:"addr,omitempty"`
-	Hostname             string `json:"hostname,omitempty"`
-	HostnameResolveTries uint   `json:"hostname_resolve_tries,omitempty"`
-	IsIP                 *bool  `json:"is_ip,omitempty"`
-	Port                 uint16 `json:"port,omitempty"`
+	Addr                 string           `json:"addr,omitempty"`
+	Hostname             string           `json:"hostname,omitempty"`
+	HostnameResolveTries uint             `json:"hostname_resolve_tries,omitempty"`
+	HostnameChanges      []hostnameChange `json:"hostname_changes,omitempty"`
+	IsIP                 *bool            `json:"is_ip,omitempty"`
+	Port                 uint16           `json:"port,omitempty"`
 
 	// Success is a special field from probe messages, containing information
 	// whether request was successful or not.
@@ -410,6 +411,10 @@ func (p *jsonPrinter) printStatistics(s stats) {
 		TotalSuccessfulProbes:   s.totalSuccessfulProbes,
 		TotalUnsuccessfulProbes: s.totalUnsuccessfulProbes,
 		TotalUptime:             s.totalUptime.Seconds(),
+	}
+
+	if len(s.hostnameChanges) > 1 {
+		data.HostnameChanges = s.hostnameChanges
 	}
 
 	loss := (float32(data.TotalUnsuccessfulProbes) / float32(data.TotalPackets)) * 100

--- a/statsprinter.go
+++ b/statsprinter.go
@@ -113,6 +113,17 @@ func (p *planePrinter) printStatistics(s stats) {
 		colorYellow("retried to resolve hostname ")
 		colorRed("%d ", s.retriedHostnameResolves)
 		colorYellow("times\n")
+
+		if len(s.hostnameChanges) >= 2 {
+			for i := 0; i < len(s.hostnameChanges)-1; i++ {
+				colorYellow("IP address changed from ")
+				colorRed(s.hostnameChanges[i].addr.String())
+				colorYellow(" to ")
+				colorGreen(s.hostnameChanges[i+1].addr.String())
+				colorYellow(" at ")
+				colorLightBlue("%v\n", s.hostnameChanges[i+1].when.Format(timeFormat))
+			}
+		}
 	}
 
 	if s.rttResults.hasResults {

--- a/statsprinter.go
+++ b/statsprinter.go
@@ -404,6 +404,7 @@ func (p *jsonPrinter) printStatistics(s stats) {
 	data := JSONData{
 		Type:     statisticsEvent,
 		Message:  fmt.Sprintf("stats for %s", s.hostname),
+		Addr:     s.ip.String(),
 		Hostname: s.hostname,
 
 		StartTimestamp:          &s.startTime,

--- a/tcping.go
+++ b/tcping.go
@@ -264,7 +264,9 @@ func processUserInput(tcpStats *stats) {
 	tcpStats.probesBeforeQuit = *probesBeforeQuit
 
 	// this serves as a default starting value for tracking changes.
-	tcpStats.hostnameChanges = []hostnameChange{{tcpStats.ip, time.Now()}}
+	tcpStats.hostnameChanges = []hostnameChange{
+		{tcpStats.ip, time.Now()},
+	}
 
 	if tcpStats.hostname == tcpStats.ip.String() {
 		tcpStats.isIP = true
@@ -424,11 +426,6 @@ func retryResolve(tcpStats *stats) {
 		tcpStats.ip = resolveHostname(tcpStats)
 		tcpStats.ongoingUnsuccessfulProbes = 0
 		tcpStats.retriedHostnameResolves += 1
-
-		tcpStats.hostnameChanges = append(tcpStats.hostnameChanges, hostnameChange{
-			Addr: tcpStats.ip,
-			When: time.Now(),
-		})
 	}
 }
 
@@ -549,6 +546,14 @@ func (tcpStats *stats) handleConnSuccess(rtt float32, now time.Time) {
 		tcpStats.wasDown = false
 		tcpStats.ongoingUnsuccessfulProbes = 0
 		tcpStats.ongoingSuccessfulProbes = 0
+
+		lastAddr := tcpStats.hostnameChanges[len(tcpStats.hostnameChanges)-1].Addr
+		if lastAddr != tcpStats.ip {
+			tcpStats.hostnameChanges = append(tcpStats.hostnameChanges, hostnameChange{
+				Addr: tcpStats.ip,
+				When: time.Now(),
+			})
+		}
 	}
 
 	if tcpStats.startOfUptime.IsZero() {

--- a/tcping.go
+++ b/tcping.go
@@ -125,8 +125,8 @@ type replyMsg struct {
 }
 
 type hostnameChange struct {
-	addr netip.Addr
-	when time.Time
+	Addr netip.Addr `json:"addr,omitempty"`
+	When time.Time  `json:"when,omitempty"`
 }
 
 type (
@@ -426,8 +426,8 @@ func retryResolve(tcpStats *stats) {
 		tcpStats.retriedHostnameResolves += 1
 
 		tcpStats.hostnameChanges = append(tcpStats.hostnameChanges, hostnameChange{
-			addr: tcpStats.ip,
-			when: time.Now(),
+			Addr: tcpStats.ip,
+			When: time.Now(),
 		})
 	}
 }


### PR DESCRIPTION
## Describe your changes

tcping now keeps tracks of successful(!) hostname changes, and reports them in json/plane printers in statistics screen

<details><summary>Example output of multiple unsuccessful resolves and some successful ones</summary>
This uses old output format, there are screenshots of the new format below
<pre>
> go run . fb.com 443 -r 2
TCPinging fb.com on port 443
No reply from fb.com (2a03:2880:f103:83:face:b00c:0:25de) on port 443 TCP_conn=1
No reply from fb.com (2a03:2880:f103:83:face:b00c:0:25de) on port 443 TCP_conn=2
retrying to resolve fb.com
No reply from fb.com (2a03:2880:f162:81:face:b00c:0:25de) on port 443 TCP_conn=1
No reply from fb.com (2a03:2880:f162:81:face:b00c:0:25de) on port 443 TCP_conn=2
retrying to resolve fb.com
No response received for 4 seconds
Reply from fb.com (157.240.11.35) on port 443 TCP_conn=1 time=182.082 ms
Reply from fb.com (157.240.11.35) on port 443 TCP_conn=2 time=179.312 ms
Reply from fb.com (157.240.11.35) on port 443 TCP_conn=3 time=181.029 ms
Reply from fb.com (157.240.11.35) on port 443 TCP_conn=4 time=182.631 ms
Reply from fb.com (157.240.11.35) on port 443 TCP_conn=5 time=180.608 ms
Reply from fb.com (157.240.11.35) on port 443 TCP_conn=6 time=180.115 ms
No reply from fb.com (157.240.11.35) on port 443 TCP_conn=1
No reply from fb.com (157.240.11.35) on port 443 TCP_conn=2
retrying to resolve fb.com
No reply from fb.com (157.240.11.35) on port 443 TCP_conn=1
No reply from fb.com (157.240.11.35) on port 443 TCP_conn=2
retrying to resolve fb.com
No reply from fb.com (157.240.11.35) on port 443 TCP_conn=1
No reply from fb.com (157.240.11.35) on port 443 TCP_conn=2
retrying to resolve fb.com
No reply from fb.com (157.240.11.35) on port 443 TCP_conn=1
No reply from fb.com (157.240.11.35) on port 443 TCP_conn=2
retrying to resolve fb.com
No reply from fb.com (2a03:2880:f103:83:face:b00c:0:25de) on port 443 TCP_conn=1
No reply from fb.com (2a03:2880:f103:83:face:b00c:0:25de) on port 443 TCP_conn=2
retrying to resolve fb.com
No reply from fb.com (2a03:2880:f10d:83:face:b00c:0:25de) on port 443 TCP_conn=1
No reply from fb.com (2a03:2880:f10d:83:face:b00c:0:25de) on port 443 TCP_conn=2
retrying to resolve fb.com
No reply from fb.com (2a03:2880:f131:83:face:b00c:0:25de) on port 443 TCP_conn=1
No reply from fb.com (2a03:2880:f131:83:face:b00c:0:25de) on port 443 TCP_conn=2
retrying to resolve fb.com
No reply from fb.com (2a03:2880:f162:81:face:b00c:0:25de) on port 443 TCP_conn=1
No reply from fb.com (2a03:2880:f162:81:face:b00c:0:25de) on port 443 TCP_conn=2
retrying to resolve fb.com
No reply from fb.com (2a03:2880:f162:81:face:b00c:0:25de) on port 443 TCP_conn=1
No reply from fb.com (2a03:2880:f162:81:face:b00c:0:25de) on port 443 TCP_conn=2
retrying to resolve fb.com
No reply from fb.com (2a03:2880:f162:81:face:b00c:0:25de) on port 443 TCP_conn=1
No reply from fb.com (2a03:2880:f162:81:face:b00c:0:25de) on port 443 TCP_conn=2
retrying to resolve fb.com
No reply from fb.com (2a03:2880:f175:181:face:b00c:0:25de) on port 443 TCP_conn=1
No reply from fb.com (2a03:2880:f175:181:face:b00c:0:25de) on port 443 TCP_conn=2
retrying to resolve fb.com
No reply from fb.com (2a03:2880:f103:83:face:b00c:0:25de) on port 443 TCP_conn=1
No reply from fb.com (2a03:2880:f103:83:face:b00c:0:25de) on port 443 TCP_conn=2
retrying to resolve fb.com
No reply from fb.com (2a03:2880:f112:182:face:b00c:0:25de) on port 443 TCP_conn=1
No reply from fb.com (2a03:2880:f112:182:face:b00c:0:25de) on port 443 TCP_conn=2
retrying to resolve fb.com
No reply from fb.com (2a03:2880:f101:83:face:b00c:0:25de) on port 443 TCP_conn=1
No reply from fb.com (2a03:2880:f101:83:face:b00c:0:25de) on port 443 TCP_conn=2
retrying to resolve fb.com
No reply from fb.com (2a03:2880:f111:83:face:b00c:0:25de) on port 443 TCP_conn=1
No reply from fb.com (2a03:2880:f111:83:face:b00c:0:25de) on port 443 TCP_conn=2
retrying to resolve fb.com
No response received for 29 seconds
Reply from fb.com (31.13.72.36) on port 443 TCP_conn=1 time=162.855 ms
Reply from fb.com (31.13.72.36) on port 443 TCP_conn=2 time=76.537 ms
No reply from fb.com (31.13.72.36) on port 443 TCP_conn=1
No response received for 0 seconds
Reply from fb.com (31.13.72.36) on port 443 TCP_conn=1 time=40.054 ms
No reply from fb.com (31.13.72.36) on port 443 TCP_conn=1
No response received for 0 seconds
Reply from fb.com (31.13.72.36) on port 443 TCP_conn=1 time=40.104 ms
Reply from fb.com (31.13.72.36) on port 443 TCP_conn=2 time=40.596 ms
Reply from fb.com (31.13.72.36) on port 443 TCP_conn=3 time=36.128 ms
No reply from fb.com (31.13.72.36) on port 443 TCP_conn=1
No response received for 0 seconds
Reply from fb.com (31.13.72.36) on port 443 TCP_conn=1 time=38.430 ms
^C
--- fb.com (31.13.72.36) TCPing statistics ---
50 probes transmitted on port 443 | 13 received, 74.00% packet loss
successful probes:   13
unsuccessful probes: 37
last successful probe:   2023-05-28 20:53:10
last unsuccessful probe: 2023-05-28 20:53:10
total uptime:   13 seconds
total downtime: 37 seconds
longest consecutive uptime:   6 seconds from 2023-05-28 20:52:26 to 2023-05-28 20:52:32
longest consecutive downtime: 29 seconds from 2023-05-28 20:52:32 to 2023-05-28 20:53:01
retried to resolve hostname 17 times
IP address changed from 2a03:2880:f103:83:face:b00c:0:25de to 157.240.11.35 at 2023-05-28 20:52:26
IP address changed from 157.240.11.35 to 31.13.72.36 at 2023-05-28 20:53:02
rtt min/avg/max: 36.128/116.960/182.631 ms
--------------------------------------
TCPing started at: 2023-05-28 20:52:21
TCPing ended at:   2023-05-28 20:53:11
duration (HH:MM:SS): 00:00:50
</pre>
</details> 

Printers:
![image](https://github.com/pouriyajamshidi/tcping/assets/5007271/cb8fc835-8760-434d-a072-359c8693df14)
![image](https://github.com/pouriyajamshidi/tcping/assets/5007271/7327bb61-ec05-4262-a608-8b48150a7632)

## Issue ticket number and link

Closes #17 

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have run `make check` and there are no failures.

## Type of change

- [x] New feature (non-breaking change which adds functionality)