### PR TITLE
tests: add basic test server and probe success/fail tests

### DIFF
--- a/statsprinter_test.go
+++ b/statsprinter_test.go
@@ -5,6 +5,20 @@ import (
 	"time"
 )
 
+// fakePrinter is a fake test implementation of a printer
+// that does nothing.
+type fakePrinter struct{}
+
+func (fp *fakePrinter) printStart(_ string, _ uint16)                              {}
+func (fp *fakePrinter) printProbeFail(_, _ string, _ uint16, _ uint)               {}
+func (fp *fakePrinter) printRetryingToResolve(_ string)                            {}
+func (fp *fakePrinter) printTotalDownTime(_ time.Duration)                         {}
+func (fp *fakePrinter) printStatistics(_ stats)                                    {}
+func (fp *fakePrinter) printVersion()                                              {}
+func (fp *fakePrinter) printInfo(_ string, _ ...interface{})                       {}
+func (fp *fakePrinter) printError(_ string, _ ...interface{})                      {}
+func (fp *fakePrinter) printProbeSuccess(_, _ string, _ uint16, _ uint, _ float32) {}
+
 func TestDurationToString(t *testing.T) {
 	t.Parallel()
 

--- a/statsprinter_test.go
+++ b/statsprinter_test.go
@@ -5,19 +5,19 @@ import (
 	"time"
 )
 
-// fakePrinter is a fake test implementation of a printer
-// that does nothing.
-type fakePrinter struct{}
+// dummyPrinter is a fake test implementation
+// of a printer that does nothing.
+type dummyPrinter struct{}
 
-func (fp *fakePrinter) printStart(_ string, _ uint16)                              {}
-func (fp *fakePrinter) printProbeFail(_, _ string, _ uint16, _ uint)               {}
-func (fp *fakePrinter) printRetryingToResolve(_ string)                            {}
-func (fp *fakePrinter) printTotalDownTime(_ time.Duration)                         {}
-func (fp *fakePrinter) printStatistics(_ stats)                                    {}
-func (fp *fakePrinter) printVersion()                                              {}
-func (fp *fakePrinter) printInfo(_ string, _ ...interface{})                       {}
-func (fp *fakePrinter) printError(_ string, _ ...interface{})                      {}
-func (fp *fakePrinter) printProbeSuccess(_, _ string, _ uint16, _ uint, _ float32) {}
+func (fp *dummyPrinter) printStart(_ string, _ uint16)                              {}
+func (fp *dummyPrinter) printProbeFail(_, _ string, _ uint16, _ uint)               {}
+func (fp *dummyPrinter) printRetryingToResolve(_ string)                            {}
+func (fp *dummyPrinter) printTotalDownTime(_ time.Duration)                         {}
+func (fp *dummyPrinter) printStatistics(_ stats)                                    {}
+func (fp *dummyPrinter) printVersion()                                              {}
+func (fp *dummyPrinter) printInfo(_ string, _ ...interface{})                       {}
+func (fp *dummyPrinter) printError(_ string, _ ...interface{})                      {}
+func (fp *dummyPrinter) printProbeSuccess(_, _ string, _ uint16, _ uint, _ float32) {}
 
 func TestDurationToString(t *testing.T) {
 	t.Parallel()

--- a/tcping_test.go
+++ b/tcping_test.go
@@ -15,7 +15,7 @@ import (
 func createTestStats(t *testing.T) *stats {
 	addr, err := netip.ParseAddr("127.0.0.1")
 	s := stats{
-		printer: &fakePrinter{},
+		printer: &dummyPrinter{},
 		ip:      addr,
 		port:    12345,
 		ticker:  time.NewTicker(time.Second),

--- a/tcping_test.go
+++ b/tcping_test.go
@@ -10,8 +10,9 @@ import (
 )
 
 // createTestStats should be used to create new stats structs.
-// it uses localhost and 12345 to be tested using the testServerListen.
-// it could fail if netip.ParseAddr has failed.
+// it uses "127.0.0.1:12345" as default values, because
+// [testServerListen] use the same values.
+// It'll call t.Errorf if netip.ParseAddr has failed.
 func createTestStats(t *testing.T) *stats {
 	addr, err := netip.ParseAddr("127.0.0.1")
 	s := stats{
@@ -30,8 +31,8 @@ func createTestStats(t *testing.T) *stats {
 // testServerListen creates a new listener
 // on port 12345 and automatically starts it.
 //
-// Use t.Cleanup to close it after the test,
-// so that other tests are not affected.
+// Use t.Cleanup with srv.Close() to close it after
+// the test, so that other tests are not affected.
 //
 // It could fail if net.Listen or Accept has failed.
 func testServerListen(t *testing.T) net.Listener {

--- a/tcping_test.go
+++ b/tcping_test.go
@@ -1,11 +1,98 @@
 package main
 
 import (
+	"net"
+	"net/netip"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 )
+
+// createTestStats should be used to create new stats structs.
+// it uses localhost and 12345 to be tested using the testServerListen.
+// it could fail if netip.ParseAddr has failed.
+func createTestStats(t *testing.T) *stats {
+	addr, err := netip.ParseAddr("127.0.0.1")
+	s := stats{
+		printer: &fakePrinter{},
+		ip:      addr,
+		port:    12345,
+		ticker:  time.NewTicker(time.Second),
+	}
+	if err != nil {
+		t.Errorf("ip parse: %v", err)
+	}
+
+	return &s
+}
+
+// testServerListen creates a new listener
+// on port 12345 and automatically starts it.
+//
+// Use t.Cleanup to close it after the test,
+// so that other tests are not affected.
+//
+// It could fail if net.Listen or Accept has failed.
+func testServerListen(t *testing.T) net.Listener {
+	srv, err := net.Listen("tcp", ":12345")
+	if err != nil {
+		t.Errorf("test server: %v", err)
+	}
+
+	go func() {
+		for {
+			c, err := srv.Accept()
+			if err != nil {
+				return
+			}
+
+			c.Close()
+		}
+	}()
+
+	return srv
+}
+
+func TestProbeSuccess(t *testing.T) {
+	stats := createTestStats(t)
+	stats.ticker = time.NewTicker(time.Nanosecond)
+	srv := testServerListen(t)
+	t.Cleanup(func() {
+		if err := srv.Close(); err != nil {
+			t.Errorf("srv close: %v", err)
+		}
+	})
+
+	expectedSuccessfull := 100
+
+	for i := 0; i < expectedSuccessfull; i++ {
+		tcping(stats)
+	}
+
+	assert.Equal(t, stats.totalSuccessfulProbes, uint(expectedSuccessfull))
+	assert.Equal(t, stats.ongoingSuccessfulProbes, uint(expectedSuccessfull))
+
+	// TODO: change when custom ping intervals will be introduced
+	assert.Equal(t, stats.totalUptime, 100*time.Second)
+}
+
+func TestProbeFail(t *testing.T) {
+	stats := createTestStats(t)
+	stats.ticker = time.NewTicker(time.Nanosecond)
+
+	expectedFailed := 100
+
+	for i := 0; i < expectedFailed; i++ {
+		tcping(stats)
+	}
+
+	assert.Equal(t, stats.totalUnsuccessfulProbes, uint(expectedFailed))
+	assert.Equal(t, stats.ongoingUnsuccessfulProbes, uint(expectedFailed))
+
+	// TODO: change when custom ping intervals will be introduced
+	assert.Equal(t, stats.totalDowntime, 100*time.Second)
+}
 
 func TestPermuteArgs(t *testing.T) {
 	type args struct {


### PR DESCRIPTION
## Describe your changes

This is mostly a POC PR for improving tests and code coverage.

This PR adds:

- Test server for making probes
- Test printer that simply implements `printer` interface but does nothing. Printers could\should be tester separately.
- Example tests for `handleConnSuccess`/`handleConnError`

More tests could be added later as a part of other PRs

## Checklist before requesting a review

- [x] If it is a core feature, I have added tests.
- [x] I have run `make check` and there are no failures.

## Type of change

- [x] Tests
