### PR TITLE
Refactor/stdin logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ tcping
 .DS_Store
 .vscode
 *.code-workspace
+patches/


### PR DESCRIPTION
## Summary

Refactors `STDIN` logic used to check for Enter key press to display the results.

We were looking for unnecessary characters and then using only one.

This PR converts the monitor channel to bool to make the code cleaner.