### PR TITLE
fix Windows Enter key detection

### DIFF
--- a/tcping.go
+++ b/tcping.go
@@ -633,7 +633,7 @@ func monitorStdin(stdinChan chan bool) {
 	for {
 		input, _ := reader.ReadString('\n')
 
-		if input == "\n" {
+		if input == "\n" || input == "\r" || input == "\r\n" {
 			stdinChan <- true
 		}
 	}


### PR DESCRIPTION
## Summary

In PR https://github.com/pouriyajamshidi/tcping/commit/11b5aedcd340470a81b46a743df94a055c1d0e5c the `stdin` logic was refactored and this caused tcping to ignore Windows' `printStatistics` request.

This patch fixes it.