### PR TITLE
fixed CI warnings #98

### DIFF
--- a/.github/workflows/container-publish.yml
+++ b/.github/workflows/container-publish.yml
@@ -37,9 +37,9 @@ jobs:
       - name: Extract Version
         id: version_step
         run: |
-          echo "##[set-output name=version;]VERSION=${GITHUB_REF#$"refs/tags/v"}"
-          echo "##[set-output name=version_tag;]$GITHUB_REPOSITORY:${GITHUB_REF#$"refs/tags/v"}"
-          echo "##[set-output name=latest_tag;]$GITHUB_REPOSITORY:latest"
+          echo "version=${GITHUB_REF#"refs/tags/v"}" >> $GITHUB_ENV
+          echo "version_tag=${GITHUB_REPOSITORY}:${GITHUB_REF#"refs/tags/v"}" >> $GITHUB_ENV
+          echo "latest_tag=${GITHUB_REPOSITORY}:latest" >> $GITHUB_ENV
       - name: Print Version
         run: |
           echo ${{steps.version_step.outputs.version}}

--- a/.github/workflows/container-publish.yml
+++ b/.github/workflows/container-publish.yml
@@ -42,9 +42,9 @@ jobs:
           echo "latest_tag=${GITHUB_REPOSITORY}:latest" >> $GITHUB_ENV
       - name: Print Version
         run: |
-          echo ${{steps.version_step.outputs.version}}
-          echo ${{steps.version_step.outputs.version_tag}}
-          echo ${{steps.version_step.outputs.latest_tag}}
+          echo ${{ env.version }}
+          echo ${{ env.version_tag }}
+          echo ${{ env.latest_tag }}
 
       - name: Checkout repository
         uses: actions/checkout@v3


### PR DESCRIPTION
# Important

This pr fixes the `GitHub Actions: Deprecating save-state and set-output commands`

## Describe your changes
changes these lines
https://github.com/pouriyajamshidi/tcping/blob/5ec50b47c4cca6a770523933d3c4d99910e81191/.github/workflows/container-publish.yml#L40C1-L42C74

## Issue ticket number and link

https://github.com/pouriyajamshidi/tcping/issues/98

Closes #98 

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added tests.
- [ ] I have run `make check` and there are no failures.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
