### PR TITLE
reduce RTT floating point precision when storing to db

### DIFF
--- a/db.go
+++ b/db.go
@@ -187,7 +187,7 @@ func (s database) saveStats(stat stats) error {
 		stat.totalUptime.String(), stat.totalDowntime.String(),
 		longestUptimeDuration, longestUptimeStart, longestUptimeEnd,
 		longestDowntimeDuration, longestDowntimeStart, longestDowntimeEnd,
-		stat.rttResults.min, stat.rttResults.average, stat.rttResults.max,
+		fmt.Sprintf("%.3f", stat.rttResults.min), fmt.Sprintf("%.3f", stat.rttResults.average), fmt.Sprintf("%.3f", stat.rttResults.max),
 		stat.startTime.Format(timeFormat), stat.endTime.Format(timeFormat), totalDuration,
 	)
 

--- a/db_test.go
+++ b/db_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"math"
 	"net/netip"
 	"strconv"
 	"testing"
@@ -90,6 +91,10 @@ func TestDbSaveStats(t *testing.T) {
 
 	isNil(t, err)
 	rows.Close()
+
+	stat.rttResults.min = toFixedFloat(stat.rttResults.min, 3)
+	stat.rttResults.average = toFixedFloat(stat.rttResults.average, 3)
+	stat.rttResults.max = toFixedFloat(stat.rttResults.max, 3)
 
 	t.Log("the line number will tell you where the error happend")
 	Equals(t, addr, stat.userInput.ip.String())
@@ -230,4 +235,19 @@ func isNil(t *testing.T, value any) {
 		t.Logf(`expected "%v" to be nil`, value)
 		t.FailNow()
 	}
+}
+
+// toFixedFloat takes in a float and the precision number
+// and will round it to that specified precision
+// works for small numbers
+//
+// example: toFixedFloat(3.14159, 3) -> 3.142
+func toFixedFloat(input float32, precision int) float32 {
+	num := float64(input)
+	round := func(num float64) int {
+		return int(num + math.Copysign(0.5, num))
+	}
+
+	output := math.Pow(10, float64(precision))
+	return float32(float64(round(num*output)) / output)
 }


### PR DESCRIPTION
# Important

Fix db rtt floating point number to .3f

## Issue ticket number and link

Closes https://github.com/pouriyajamshidi/tcping/issues/146

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added tests.
- [x] I have run `make check` and there are no failures.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

