### PR TITLE
Added extra precision for seconds when under 1 second

### DIFF
--- a/statsprinter.go
+++ b/statsprinter.go
@@ -545,6 +545,8 @@ func durationToString(duration time.Duration) string {
 	// Seconds
 	case seconds == 1:
 		return fmt.Sprintf("%.0f second", seconds)
+	case seconds < 1:
+		return fmt.Sprintf("%.1f seconds", seconds)
 	default:
 		return fmt.Sprintf("%.0f seconds", seconds)
 

--- a/statsprinter_test.go
+++ b/statsprinter_test.go
@@ -77,6 +77,11 @@ func TestDurationToString(t *testing.T) {
 			duration: time.Duration(59*time.Hour + 10*time.Minute + 5*time.Second),
 			want:     "59 hours 10 minutes 5 seconds",
 		},
+		{
+			name:     "0.5 seconds",
+			duration: time.Duration(500 * time.Millisecond),
+			want:     "0.5 seconds",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
fixes #162

Added test for 0.5 seconds to statsprinter_test.go

# Important

**Please provide the requested parameters below to help us review your pull request.**

**Pull requests without a body or explanation will be rejected.**

## Describe your changes
Within durationToString when passed a duration of 0 hours, 0 minutes and a second value less that was not 1, it was rounding to .0f resulting in milliseconds not being returned. I added in a case for if duration is less than 1 second.

This fix currently only accounts for the case when the duration is 0 hours 0 minutes 0.x seconds. If the hours or minutes are not 0 then milliseconds are not counted.

## Issue ticket number and link

Closes #162 

## Checklist before requesting a review

- [X ] I have performed a self-review of my code
- [X] If it is a core feature, I have added tests.
- [X ] I have run `make check` and there are no failures.

## Type of change

- [X ] Bug fix (non-breaking change which fixes an issue)
