### PR TITLE
Added support for linux arm64 in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,17 @@ build: clean update tidyup format vet test
 	 @rm $(EXEC_DIR)tcping
 
 	@echo
+	@echo "[+] Building the Linux ARM version"
+	@env GOOS=linux GOARCH=arm64 go build -ldflags "-s -w" -o $(EXEC_DIR)tcping
+
+	@echo "[+] Packaging the Linux ARM version"
+	@tar -czvf $(EXEC_DIR)tcping_Linux_ARM.tar.gz -C $(EXEC_DIR) tcping > /dev/null
+	@sha256sum $(EXEC_DIR)tcping_Linux_ARM.tar.gz
+
+	@echo "[+] Removing the Linux ARM binary"
+	@rm $(EXEC_DIR)tcping
+
+	@echo
 	@echo "[+] Building the Windows version"
 	@env GOOS=windows GOARCH=amd64 go build -ldflags "-s -w" -o $(EXEC_DIR)tcping.exe
 


### PR DESCRIPTION
# Important

Changes to Makefile

## Describe your changes

Added support for Linux arm 64 following the structure of the code in the Makefile. Tested that the executable is generated properly and does not break any of the existing code.

## Issue ticket number and link

#45

## Checklist before requesting a review

- [yes] I have performed a self-review of my code
- [ ] If it is a core feature, I have added tests.
- [yes] I have run `make check` and there are no failures.

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
