### PR TITLE
display `second` instead of `seconds` on probe failures that convert …

### DIFF
--- a/statsprinter.go
+++ b/statsprinter.go
@@ -570,10 +570,8 @@ func durationToString(duration time.Duration) string {
 	// Seconds
 	case seconds == 0 || seconds == 1 || seconds >= 1 && seconds < 1.1:
 		return fmt.Sprintf("%.0f second", seconds)
-
-	// Milliseconds
 	case seconds < 1:
-		return fmt.Sprintf("%.1f milliseconds", seconds)
+		return fmt.Sprintf("%.1f seconds", seconds)
 
 	default:
 		return fmt.Sprintf("%.0f seconds", seconds)

--- a/statsprinter.go
+++ b/statsprinter.go
@@ -568,7 +568,7 @@ func durationToString(duration time.Duration) string {
 		return fmt.Sprintf("%.0f minute %.0f seconds", minutes, seconds)
 
 	// Seconds
-	case seconds == 1 || seconds < 1.1:
+	case seconds == 0 || seconds == 1 || seconds >= 1 && seconds < 1.1:
 		return fmt.Sprintf("%.0f second", seconds)
 
 	// Milliseconds

--- a/statsprinter.go
+++ b/statsprinter.go
@@ -568,12 +568,14 @@ func durationToString(duration time.Duration) string {
 		return fmt.Sprintf("%.0f minute %.0f seconds", minutes, seconds)
 
 	// Seconds
-	case seconds == 1:
+	case seconds == 1 || seconds < 1.1:
 		return fmt.Sprintf("%.0f second", seconds)
+
+	// Milliseconds
 	case seconds < 1:
-		return fmt.Sprintf("%.1f seconds", seconds)
+		return fmt.Sprintf("%.1f milliseconds", seconds)
+
 	default:
 		return fmt.Sprintf("%.0f seconds", seconds)
-
 	}
 }

--- a/statsprinter_test.go
+++ b/statsprinter_test.go
@@ -78,9 +78,9 @@ func TestDurationToString(t *testing.T) {
 			want:     "59 hours 10 minutes 5 seconds",
 		},
 		{
-			name:     "0.5 seconds",
+			name:     "0.5 milliseconds",
 			duration: time.Duration(500 * time.Millisecond),
-			want:     "0.5 seconds",
+			want:     "0.5 milliseconds",
 		},
 	}
 	for _, tt := range tests {

--- a/statsprinter_test.go
+++ b/statsprinter_test.go
@@ -78,9 +78,9 @@ func TestDurationToString(t *testing.T) {
 			want:     "59 hours 10 minutes 5 seconds",
 		},
 		{
-			name:     "0.5 milliseconds",
+			name:     "0.5 seconds",
 			duration: time.Duration(500 * time.Millisecond),
-			want:     "0.5 milliseconds",
+			want:     "0.5 seconds",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

display `second` instead of `seconds` on probe failures that convert to a value more than 1 and less than 1.1 second
