### PR TITLE
Rewrite Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 *.sh
-executables/
 .idea/
 tcping
 tcping.exe
@@ -9,3 +8,5 @@ tcping.exe
 patches/
 *.db
 .tool-versions
+/target/
+/output/

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 # ==================================================
 
 # Meta
+SHELL := /bin/bash
 VERSION := 2.6.0
 MAINTAINER := https://github.com/pouriyajamshidi
 DESCRIPTION := Ping TCP ports using tcping. Inspired by Linux's ping utility. Written in Go

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ endif
 
 .PHONY: all build release clean update format vet test tidyup
 
-all: release
+all: build
 
 # Build for current platform
 build: $(TARGET_DIR)/$(BIN_NAME)

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ endif
 # Phony targets
 # ==================================================
 
-.PHONY: all build release clean update format vet test tidyup gifs
+.PHONY: all build release clean update format vet test tidyup container githubActions gifs
 
 all: build
 
@@ -84,6 +84,16 @@ tidyup:
 	@echo "[+] Running go mod tidy"
 	@go get -u ./...
 	@go mod tidy
+
+container: create_dirs
+	@echo "[+] Building container image"
+	@env GOOS=linux CGO_ENABLED=0 go build --ldflags '-s -w -extldflags "-static"' -o tcpingDocker
+	@docker build -t tcping:latest .
+	@rm tcpingDocker
+
+gitHubActions:
+	@echo "[+] Building container image - GitHub Actions"
+	@env GOOS=linux CGO_ENABLED=0 go build --ldflags '-s -w -extldflags "-static"' -o tcpingDocker
 
 gifs: $(GIF_ARTIFACTS)
 

--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,8 @@ build: $(TARGET_DIR)/$(BIN_NAME)
 # Build all release artifacts
 release: $(RELEASE_ARTIFACTS)
 
+check: format vet test
+
 # Remove all build artifacts
 clean:
 	rm -rf $(TARGET_DIR)/ $(OUTPUT_DIR)/

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ OUTPUT_DIR := output
 TAPES_DIR := Images/tapes
 GIFS_DIR := Images/gifs
 
-# Release outputs
+# File lists
 RELEASE_ARTIFACTS := \
 	$(OUTPUT_DIR)/tcping-freebsd-amd64-static.tar.gz \
 	$(OUTPUT_DIR)/tcping-freebsd-amd64-dynamic.tar.gz \
@@ -33,6 +33,10 @@ RELEASE_ARTIFACTS := \
 	$(OUTPUT_DIR)/tcping-windows-arm64-dynamic.zip \
 	$(OUTPUT_DIR)/tcping-amd64.deb \
 	$(OUTPUT_DIR)/tcping-arm64.deb
+GIF_ARTIFACTS := \
+	$(GIFS_DIR)/tcping.gif \
+	$(GIFS_DIR)/tcping_resolve.gif \
+	$(GIFS_DIR)/tcping_json_pretty.gif
 
 # Conditionals
 ifeq ($(OS),Windows_NT)
@@ -45,7 +49,7 @@ endif
 # Phony targets
 # ==================================================
 
-.PHONY: all build release clean update format vet test tidyup
+.PHONY: all build release clean update format vet test tidyup gifs
 
 all: build
 
@@ -80,6 +84,8 @@ tidyup:
 	@echo "[+] Running go mod tidy"
 	@go get -u ./...
 	@go mod tidy
+
+gifs: $(GIF_ARTIFACTS)
 
 # ==================================================
 # Raw binaries
@@ -161,3 +167,16 @@ $(OUTPUT_DIR)/tcping-%.deb: $(TARGET_DIR)/linux-%-static/tcping $(OUTPUT_DIR)/
 # ==================================================
 # Miscellaneous outputs
 # ==================================================
+
+# GIF generation
+$(GIFS_DIR)/%.gif: $(TAPES_DIR)/%.tape FORCE
+	@echo "[+] Generating GIF: $@"
+	@vhs $< -o $@
+
+# ==================================================
+# Helpers
+# ==================================================
+
+# Force target
+# See https://www.gnu.org/software/make/manual/html_node/Force-Targets.html
+FORCE:

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ This document is also available in [Chinese | 中国人](README.cn.md).
 
 ## Download
 
-We offer prebuilt binaries for various OSes and architectures. You can find them on 
+We offer prebuilt binaries for various OSes and architectures (Windows, Linux and macOS). You can find them on 
 [the release page](https://github.com/pouriyajamshidi/tcping/releases/latest/).
 
 When the download is complete, head to the [usage](#usage) section.

--- a/README.md
+++ b/README.md
@@ -80,15 +80,8 @@ Here are some of the features of **TCPING**:
 
 ## Download
 
-- ### [Windows](https://github.com/pouriyajamshidi/tcping/releases/latest/download/tcping_Windows.zip)
-
-- ### [Linux](https://github.com/pouriyajamshidi/tcping/releases/latest/download/tcping_Linux.tar.gz) - Also available through `brew` and [.deb package](#linux---debian-and-ubuntu)
-
-- ### [macOS](https://github.com/pouriyajamshidi/tcping/releases/latest/download/tcping_MacOS.tar.gz) - Also available through `brew`
-
-- ### [macOS M1 - ARM](https://github.com/pouriyajamshidi/tcping/releases/latest/download/tcping_MacOS_ARM.tar.gz) - Also available through `brew`
-
-- ### [FreeBSD](https://github.com/pouriyajamshidi/tcping/releases/latest/download/tcping_FreeBSD.tar.gz)
+We offer prebuilt binaries for various OSes and architectures. You can find them on 
+[the release page](https://github.com/pouriyajamshidi/tcping/releases/latest/).
 
 When the download is complete, head to the [usage](#usage) section.
 
@@ -124,7 +117,7 @@ When the download is complete, head to the [usage](#usage) section.
   make build
   ```
 
-  This will give you a compressed file with executables for all the supported operating systems inside the `executables` folder.
+  This will produce an executable under `target/` folder.
 
 ---
 

--- a/tcping.go
+++ b/tcping.go
@@ -18,8 +18,9 @@ import (
 	"github.com/google/go-github/v45/github"
 )
 
+var version = "" // set at compile time 
+
 const (
-	version    = "2.6.0"
 	owner      = "pouriyajamshidi"
 	repo       = "tcping"
 	dnsTimeout = 2 * time.Second


### PR DESCRIPTION
## Describe your changes

Rewrite Makefile to rely less on `.PHONY` targets.

While working on the logic problem in #242, I found the current Makefile setup to be quite clumsy. No offence to the previous author, but it seems to me that it's quite hastily cobbled together. Lots of unnecessary code duplication and under-utilisation of the strengths of make (specifically, its focus on file generation).

So I decided to overhaul the whole thing. A bit drastic, but I believe it's for a good cause.

## Issue ticket number and link

Closes #242.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added tests.
- [ ] I have run `make check` and there are no failures.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update
