### PR TITLE
Containerise build process

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+# gitignore
+*.sh
+.idea/
+tcping
+tcping.exe
+.DS_Store
+.vscode
+*.code-workspace
+patches/
+*.db
+.tool-versions
+/target/
+/output/
+
+# container files
+Dockerfile

--- a/.github/workflows/container-publish.yml
+++ b/.github/workflows/container-publish.yml
@@ -84,9 +84,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: build Docker image using Makefile
-        run: make gitHubActions
-
       # Extract metadata (tags, labels) for Docker
       # https://github.com/docker/metadata-action
       - name: Extract Docker metadata

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,7 @@ FROM docker.io/golang:1.23-alpine3.20 AS build
 WORKDIR /build
 
 # Install dependencies
-RUN apk update
-RUN apk add bash make
+RUN apk --no-cache add bash make
 
 # Cache libraries
 COPY go.mod go.sum ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,27 @@
+# Build stage
+##################################################
+FROM docker.io/golang:1.23-alpine3.20 AS build
+
+WORKDIR /build
+
+# Install dependencies
+RUN apk update
+RUN apk add bash make
+
+# Cache libraries
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Build
+COPY ./ ./
+RUN make build
+
+# Final stage
+##################################################
 FROM scratch
 
 LABEL maintainer="Pouriya Jamshidi"
 
-COPY tcpingDocker /usr/bin/tcping
+COPY --from=build /build/target/tcping /usr/bin/
 
 ENTRYPOINT ["tcping"]

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ endif
 # Phony targets
 # ==================================================
 
-.PHONY: all build release clean update format vet test tidyup container githubActions gifs
+.PHONY: all build release clean update format vet test tidyup container gifs
 
 all: build
 
@@ -88,15 +88,9 @@ tidyup:
 	@go get -u ./...
 	@go mod tidy
 
-container: create_dirs
+container:
 	@echo "[+] Building container image"
-	@env GOOS=linux CGO_ENABLED=0 go build --ldflags '-s -w -extldflags "-static"' -o tcpingDocker
 	@docker build -t tcping:latest .
-	@rm tcpingDocker
-
-gitHubActions:
-	@echo "[+] Building container image - GitHub Actions"
-	@env GOOS=linux CGO_ENABLED=0 go build --ldflags '-s -w -extldflags "-static"' -o tcpingDocker
 
 gifs: $(GIF_ARTIFACTS)
 


### PR DESCRIPTION
## Describe your changes

Containerise the build process. Motivation detailed [here](https://github.com/pouriyajamshidi/tcping/pull/245#discussion_r1791118412), posted here verbatim:

> Currently, the build process itself is not performed in a containerised environment, which goes against the key spirits of containerisation - platform-independence and reproducibility. In short, the build process in its current state is dependent on a working toolchain on the host, which alongside its other environmental factors is largely opaque to the end user (or even to the packager themselves). Setting up the build environment in a containerised environment improves the observability, reliability, and trustworthiness of the build artefact(s).
>
> As of how a multi-stage Dockerfile fits into this equation, this is just so that we don't ship a massive image that unnecessarily contains the toolchain to the user. The build happens in `imageA`; then we copy the relevant artefacts into `imageB` and ship it. It's very well supported at this point and not at all complicated to set up.

## Issue ticket number and link

N/A

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added tests.
- [x] I have run `make check` and there are no failures.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

I guess this counts as a bug fix?