### PR TITLE
Fix/sqlite hyphen hostname bug

### DIFF
--- a/db.go
+++ b/db.go
@@ -119,9 +119,11 @@ func newDB(dbPath string, args []string) *database {
 
 // newTableName will return correctly formatted table name
 // formatting the table name as "example_com_port_hour_minute_sec_day_month_year"
-// table name can't have '.' and can't start with numbers
+// table name can't have '.','-' and can't start with numbers
 func newTableName(args []string) string {
-	tableName := fmt.Sprintf("%s_%s_%s", strings.ReplaceAll(args[0], ".", "_"), args[1], time.Now().Format("15_04_05_01_02_2006"))
+	sanitizedHost := strings.ReplaceAll(args[0], ".", "_")
+	sanitizedHost = strings.ReplaceAll(sanitizedHost, "-", "_")
+	tableName := fmt.Sprintf("%s_%s_%s", sanitizedHost, args[1], time.Now().Format("15_04_05_01_02_2006"))
 
 	if unicode.IsNumber(rune(tableName[0])) {
 		tableName = "_" + tableName


### PR DESCRIPTION
## Describe your changes
Sanitization of hostnames and ensures they are formatted correctly for SQLite compliance.
Additionally, I have updated tests to verify the sanitization of hostname.

## Issue ticket number and link

Closes [#239](https://github.com/pouriyajamshidi/tcping/issues/239)

## Checklist 

- [X] I have performed a self-review of my code
- [X] If it is a core feature, I have added tests.
- [X] I have run `make check` and there are no failures.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

