### PR TITLE
Feat/implement source addr port display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,15 @@
 ## v2.7.0 - Unreleased
 
 - new feature: implement color-less (plane printer) output through `--no-color` flag [#253](https://github.com/pouriyajamshidi/tcping/issues/253)
+- new feature: implement display of local IP address and port used to create TCP connections through `--show-local-address` flag [#249](https://github.com/pouriyajamshidi/tcping/issues/249)
 - refactor: rename `planePrinter` to `colorPrinter` to match the actual functionality of the function
 - refactor: complete rewrite of the **Makefile** thanks to @cyqsimon
 - refactor: add containerization section in the **Makefile** thanks to @cyqsimon
 - fix: crash on database writes when hostname includes a hyphen thanks to @pro0o
-- tests: add new tests for `printProbeSuccess` and `printProbeFail` thanks to @basil-gray
 - documents: add Chinese translation thanks to @edwinjhlee
 - documents: add link to [X CMD](https://x-cmd.com/pkg/tcping) thanks to @edwinjhlee
+- tests: add new tests for `printProbeSuccess` and `printProbeFail` thanks to @basil-gray
+- tests: add tests for `show-local-address` flag
 - dependencies: bump:
   - crypto v0.28.0 => v0.29.0
   - exp v0.0.0-20241004190924-225e2abe05e6 => v0.0.0-20241108190413-2d47ceb2692f

--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ The following flags are available to control the behavior of application:
 | `-v`                   | Print version                                                                                                     |
 | `-u`                   | Check for updates                                                                                                 |
 | `--show-failures-only` | Only show probe failures and omit printing probe success messages                                                 |
+| `--show-local_address` | Show the local IP address and port used for probes (unreleased - included in version 2.7.0)                       |
 
 > Without specifying the `-4` and `-6` flags, tcping will randomly select an IP address based on DNS lookups.
 

--- a/db.go
+++ b/db.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"math"
+	"net"
 	"os"
 	"strings"
 	"time"
@@ -23,12 +24,12 @@ const (
 	eventTypeHostnameChange = "hostname change"
 
 	tableSchema = `
--- Organized row names together for better readability
 CREATE TABLE %s (
     id INTEGER PRIMARY KEY,
     event_type TEXT NOT NULL, -- for the data type eg. statistics, hostname change
     timestamp DATETIME,
     addr TEXT,
+    localAddr TEXT,
     hostname TEXT,
     port INTEGER,
     hostname_resolve_retries INTEGER,
@@ -71,6 +72,7 @@ CREATE TABLE %s (
 	event_type,
 	timestamp,
 	addr,
+	localAddr,
 	hostname,
 	port,
 	hostname_resolve_retries,
@@ -95,7 +97,7 @@ CREATE TABLE %s (
 	latency_max,
 	start_time,
 	end_time,
-	total_duration) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);`
+	total_duration) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);`
 )
 
 // newDB creates a newDB with the given path and returns a pointer to the `database` struct
@@ -180,11 +182,14 @@ func (db *database) saveStats(tcping tcping) error {
 		totalDuration = tcping.endTime.Sub(tcping.startTime).String()
 	}
 
-	// data
+	// TODO: Find a clean way to include local address
+	// other printers utilize printProbeSuccess which takes the net.Conn
+	// whereas DB is having its own way
 	args := []interface{}{
 		eventTypeStatistics,
 		time.Now().Format(timeFormat),
 		tcping.userInput.ip.String(),
+		"local address",
 		tcping.userInput.hostname,
 		tcping.userInput.port,
 		tcping.retriedHostnameLookups,
@@ -275,9 +280,9 @@ func (db *database) printError(format string, args ...any) {
 }
 
 // Satisfying the "printer" interface.
-func (db *database) printProbeSuccess(hostname, ip string, port uint16, streak uint, rtt float32) {}
-func (db *database) printProbeFail(hostname, ip string, port uint16, streak uint)                 {}
-func (db *database) printRetryingToResolve(hostname string)                                       {}
-func (db *database) printTotalDownTime(downtime time.Duration)                                    {}
-func (db *database) printVersion()                                                                {}
-func (db *database) printInfo(format string, args ...any)                                         {}
+func (db *database) printProbeSuccess(_ net.Conn, _ userInput, _ uint, _ float32) {}
+func (db *database) printProbeFail(_ userInput, _ uint)                           {}
+func (db *database) printRetryingToResolve(_ string)                              {}
+func (db *database) printTotalDownTime(_ time.Duration)                           {}
+func (db *database) printVersion()                                                {}
+func (db *database) printInfo(_ string, _ ...any)                                 {}

--- a/db.go
+++ b/db.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"math"
-	"net"
 	"os"
 	"strings"
 	"time"
@@ -280,9 +279,9 @@ func (db *database) printError(format string, args ...any) {
 }
 
 // Satisfying the "printer" interface.
-func (db *database) printProbeSuccess(_ net.Conn, _ userInput, _ uint, _ float32) {}
-func (db *database) printProbeFail(_ userInput, _ uint)                           {}
-func (db *database) printRetryingToResolve(_ string)                              {}
-func (db *database) printTotalDownTime(_ time.Duration)                           {}
-func (db *database) printVersion()                                                {}
-func (db *database) printInfo(_ string, _ ...any)                                 {}
+func (db *database) printProbeSuccess(_ string, _ userInput, _ uint, _ float32) {}
+func (db *database) printProbeFail(_ userInput, _ uint)                         {}
+func (db *database) printRetryingToResolve(_ string)                            {}
+func (db *database) printTotalDownTime(_ time.Duration)                         {}
+func (db *database) printVersion()                                              {}
+func (db *database) printInfo(_ string, _ ...any)                               {}

--- a/db_test.go
+++ b/db_test.go
@@ -42,6 +42,7 @@ func TestDbSaveStats(t *testing.T) {
 
 	query := `SELECT
 addr,
+localAddr,
 hostname,
 port,
 hostname_resolve_retries,
@@ -70,7 +71,7 @@ total_duration
 FROM ` + fmt.Sprintf("%s WHERE event_type = '%s'", db.tableName, eventTypeStatistics)
 
 	var (
-		addr, hostname, port                           string
+		addr, localAddr, hostname, port                string
 		hostNameResolveTries                           int
 		totalSuccessfulProbes, totalUnsuccessfulProbes uint
 		neverSucceedProbe, neverFailedProbe            bool
@@ -88,65 +89,67 @@ FROM ` + fmt.Sprintf("%s WHERE event_type = '%s'", db.tableName, eventTypeStatis
 	)
 
 	resFunc := func(stmt *sqlite.Stmt) error {
-		Equals(t, stmt.ColumnCount(), 26)
+		Equals(t, stmt.ColumnCount(), 27)
 		var err error
 
 		// addr
 		addr = stmt.ColumnText(0)
+		// Local address
+		localAddr = stmt.ColumnText(1)
 		// hostname
-		hostname = stmt.ColumnText(1)
+		hostname = stmt.ColumnText(2)
 		// port
-		port = stmt.ColumnText(2)
+		port = stmt.ColumnText(3)
 		// hostname_resolve_retries
-		hostNameResolveTries = stmt.ColumnInt(3)
+		hostNameResolveTries = stmt.ColumnInt(4)
 		// total_successful_probes
-		totalSuccessfulProbes = uint(stmt.ColumnInt(4))
+		totalSuccessfulProbes = uint(stmt.ColumnInt(5))
 		// total_unsuccessful_probes
-		totalUnsuccessfulProbes = uint(stmt.ColumnInt(5))
+		totalUnsuccessfulProbes = uint(stmt.ColumnInt(6))
 		// never_succeed_probe
-		neverSucceedProbe = stmt.ColumnBool(6)
+		neverSucceedProbe = stmt.ColumnBool(7)
 		// never_failed_probe
-		neverFailedProbe = stmt.ColumnBool(7)
+		neverFailedProbe = stmt.ColumnBool(8)
 		// last_successful_probe
-		lastSuccessfulProbe, err = time.Parse(timeFormat, stmt.ColumnText(8))
+		lastSuccessfulProbe, err = time.Parse(timeFormat, stmt.ColumnText(9))
 		isNil(t, err)
 		// last_unsuccessful_probe
-		Equals(t, "", stmt.ColumnText(9)) // simulating never failed
+		Equals(t, "", stmt.ColumnText(10)) // simulating never failed
 		// isNil(t, err)
 		// total_packets
-		totalPackets = uint(stmt.ColumnInt(10))
+		totalPackets = uint(stmt.ColumnInt(11))
 		// total_packet_loss
-		totalPacketsLoss = float32(stmt.ColumnFloat(11))
+		totalPacketsLoss = float32(stmt.ColumnFloat(12))
 		// total_uptime
-		totalUptime = stmt.ColumnText(12)
+		totalUptime = stmt.ColumnText(13)
 		// total_downtime
-		totalDowntime = stmt.ColumnText(13)
+		totalDowntime = stmt.ColumnText(14)
 		// longest_uptime
-		longestUptime = stmt.ColumnText(14)
+		longestUptime = stmt.ColumnText(15)
 		// longest_uptime_start
-		longestUptimeStart = stmt.ColumnText(15)
+		longestUptimeStart = stmt.ColumnText(16)
 		// longest_uptime_end
-		longestUptimeEnd = stmt.ColumnText(16)
+		longestUptimeEnd = stmt.ColumnText(17)
 		// longest_downtime
-		longestDowntime = stmt.ColumnText(17)
+		longestDowntime = stmt.ColumnText(18)
 		// longest_downtime_start
-		longestDowntimeStart = stmt.ColumnText(18)
+		longestDowntimeStart = stmt.ColumnText(19)
 		// longest_downtime_end
-		longestDowntimeEnd = stmt.ColumnText(19)
+		longestDowntimeEnd = stmt.ColumnText(20)
 		// latency_min
-		lMin = float32(stmt.ColumnFloat(20))
+		lMin = float32(stmt.ColumnFloat(21))
 		// latency_avg
-		lAvg = float32(stmt.ColumnFloat(21))
+		lAvg = float32(stmt.ColumnFloat(22))
 		// latency_max
-		lMax = float32(stmt.ColumnFloat(22))
+		lMax = float32(stmt.ColumnFloat(23))
 		// start_time
-		startTimestamp, err = time.Parse(timeFormat, stmt.ColumnText(23))
+		startTimestamp, err = time.Parse(timeFormat, stmt.ColumnText(24))
 		isNil(t, err)
 		// end_time
-		endTimestamp, err = time.Parse(timeFormat, stmt.ColumnText(24))
+		endTimestamp, err = time.Parse(timeFormat, stmt.ColumnText(25))
 		isNil(t, err)
 		// total_duration
-		totalDuration = stmt.ColumnText(25)
+		totalDuration = stmt.ColumnText(26)
 		return nil
 	}
 
@@ -159,8 +162,8 @@ FROM ` + fmt.Sprintf("%s WHERE event_type = '%s'", db.tableName, eventTypeStatis
 	stat.rttResults.average = toFixedFloat(stat.rttResults.average, 3)
 	stat.rttResults.max = toFixedFloat(stat.rttResults.max, 3)
 
-	t.Log("the line number will tell you where the error happened")
 	Equals(t, addr, stat.userInput.ip.String())
+	Equals(t, localAddr, "local address")
 	Equals(t, hostname, stat.userInput.hostname)
 	Equals(t, totalUnsuccessfulProbes, stat.totalUnsuccessfulProbes)
 	Equals(t, totalSuccessfulProbes, stat.totalSuccessfulProbes)

--- a/statsprinter.go
+++ b/statsprinter.go
@@ -166,42 +166,58 @@ func (p *colorPrinter) printStatistics(t tcping) {
 	colorYellow("duration (HH:MM:SS): %v\n\n", durationTime.Format(hourFormat))
 }
 
-func (p *colorPrinter) printProbeSuccess(hostname, ip string, port uint16, streak uint, rtt float32) {
+func (p *colorPrinter) printProbeSuccess(localAddr string, userInput userInput, streak uint, rtt float32) {
 	timestamp := ""
 	if *p.showTimestamp {
 		timestamp = time.Now().Format(timeFormat)
 	}
-	if hostname == "" {
+	if userInput.hostname == "" {
 		if timestamp == "" {
-			colorLightGreen("Reply from %s on port %d TCP_conn=%d time=%.3f ms\n", ip, port, streak, rtt)
+			if userInput.showLocalAddress {
+				colorLightGreen("Reply from %s on port %d using %s TCP_conn=%d time=%.3f ms\n", userInput.ip.String(), userInput.port, localAddr, streak, rtt)
+			} else {
+				colorLightGreen("Reply from %s on port %d TCP_conn=%d time=%.3f ms\n", userInput.ip.String(), userInput.port, streak, rtt)
+			}
 		} else {
-			colorLightGreen("%s Reply from %s on port %d TCP_conn=%d time=%.3f ms\n", timestamp, ip, port, streak, rtt)
+			if userInput.showLocalAddress {
+				colorLightGreen("%s Reply from %s on port %d using %s TCP_conn=%d time=%.3f ms\n", timestamp, userInput.ip.String(), userInput.port, localAddr, streak, rtt)
+			} else {
+				colorLightGreen("%s Reply from %s on port %d TCP_conn=%d time=%.3f ms\n", timestamp, userInput.ip.String(), userInput.port, streak, rtt)
+			}
 		}
 	} else {
 		if timestamp == "" {
-			colorLightGreen("Reply from %s (%s) on port %d TCP_conn=%d time=%.3f ms\n", hostname, ip, port, streak, rtt)
+			if userInput.showLocalAddress {
+				colorLightGreen("Reply from %s (%s) on port %d using %s TCP_conn=%d time=%.3f ms\n", userInput.hostname, userInput.ip.String(), userInput.port, localAddr, streak, rtt)
+			} else {
+				colorLightGreen("Reply from %s (%s) on port %d TCP_conn=%d time=%.3f ms\n", userInput.hostname, userInput.ip.String(), userInput.port, streak, rtt)
+			}
 		} else {
-			colorLightGreen("%s Reply from %s (%s) on port %d TCP_conn=%d time=%.3f ms\n", timestamp, hostname, ip, port, streak, rtt)
+			if userInput.showLocalAddress {
+				colorLightGreen("%s Reply from %s (%s) on port %d using %s TCP_conn=%d time=%.3f ms\n", timestamp, userInput.hostname, userInput.ip.String(), userInput.port, localAddr, streak, rtt)
+			} else {
+				colorLightGreen("%s Reply from %s (%s) on port %d TCP_conn=%d time=%.3f ms\n", timestamp, userInput.hostname, userInput.ip.String(), userInput.port, streak, rtt)
+			}
 		}
 	}
 }
 
-func (p *colorPrinter) printProbeFail(hostname, ip string, port uint16, streak uint) {
+func (p *colorPrinter) printProbeFail(userInput userInput, streak uint) {
 	timestamp := ""
 	if *p.showTimestamp {
 		timestamp = time.Now().Format(timeFormat)
 	}
-	if hostname == "" {
+	if userInput.hostname == "" {
 		if timestamp == "" {
-			colorRed("No reply from %s on port %d TCP_conn=%d\n", ip, port, streak)
+			colorRed("No reply from %s on port %d TCP_conn=%d\n", userInput.ip, userInput.port, streak)
 		} else {
-			colorRed("%s No reply from %s on port %d TCP_conn=%d\n", timestamp, ip, port, streak)
+			colorRed("%s No reply from %s on port %d TCP_conn=%d\n", timestamp, userInput.ip, userInput.port, streak)
 		}
 	} else {
 		if timestamp == "" {
-			colorRed("No reply from %s (%s) on port %d TCP_conn=%d\n", hostname, ip, port, streak)
+			colorRed("No reply from %s (%s) on port %d TCP_conn=%d\n", userInput.hostname, userInput.ip, userInput.port, streak)
 		} else {
-			colorRed("%s No reply from %s (%s) on port %d TCP_conn=%d\n", timestamp, hostname, ip, port, streak)
+			colorRed("%s No reply from %s (%s) on port %d TCP_conn=%d\n", timestamp, userInput.hostname, userInput.ip, userInput.port, streak)
 		}
 	}
 }
@@ -333,42 +349,58 @@ func (p *planePrinter) printStatistics(t tcping) {
 	fmt.Printf("duration (HH:MM:SS): %v\n\n", durationTime.Format(hourFormat))
 }
 
-func (p *planePrinter) printProbeSuccess(hostname, ip string, port uint16, streak uint, rtt float32) {
+func (p *planePrinter) printProbeSuccess(localAddr string, userInput userInput, streak uint, rtt float32) {
 	timestamp := ""
 	if *p.showTimestamp {
 		timestamp = time.Now().Format(timeFormat)
 	}
-	if hostname == "" {
+	if userInput.hostname == "" {
 		if timestamp == "" {
-			fmt.Printf("Reply from %s on port %d TCP_conn=%d time=%.3f ms\n", ip, port, streak, rtt)
+			if userInput.showLocalAddress {
+				fmt.Printf("Reply from %s on port %d using %s TCP_conn=%d time=%.3f ms\n", userInput.ip.String(), userInput.port, localAddr, streak, rtt)
+			} else {
+				fmt.Printf("Reply from %s on port %d TCP_conn=%d time=%.3f ms\n", userInput.ip.String(), userInput.port, streak, rtt)
+			}
 		} else {
-			fmt.Printf("%s Reply from %s on port %d TCP_conn=%d time=%.3f ms\n", timestamp, ip, port, streak, rtt)
+			if userInput.showLocalAddress {
+				fmt.Printf("%s Reply from %s on port %d using %s TCP_conn=%d time=%.3f ms\n", timestamp, userInput.ip.String(), userInput.port, localAddr, streak, rtt)
+			} else {
+				fmt.Printf("%s Reply from %s on port %d TCP_conn=%d time=%.3f ms\n", timestamp, userInput.ip.String(), userInput.port, streak, rtt)
+			}
 		}
 	} else {
 		if timestamp == "" {
-			fmt.Printf("Reply from %s (%s) on port %d TCP_conn=%d time=%.3f ms\n", hostname, ip, port, streak, rtt)
+			if userInput.showLocalAddress {
+				fmt.Printf("Reply from %s (%s) on port %d using %s TCP_conn=%d time=%.3f ms\n", userInput.hostname, userInput.ip.String(), userInput.port, localAddr, streak, rtt)
+			} else {
+				fmt.Printf("Reply from %s (%s) on port %d TCP_conn=%d time=%.3f ms\n", userInput.hostname, userInput.ip.String(), userInput.port, streak, rtt)
+			}
 		} else {
-			fmt.Printf("%s Reply from %s (%s) on port %d TCP_conn=%d time=%.3f ms\n", timestamp, hostname, ip, port, streak, rtt)
+			if userInput.showLocalAddress {
+				fmt.Printf("%s Reply from %s (%s) on port %d using %s TCP_conn=%d time=%.3f ms\n", timestamp, userInput.hostname, userInput.ip.String(), userInput.port, localAddr, streak, rtt)
+			} else {
+				fmt.Printf("%s Reply from %s (%s) on port %d TCP_conn=%d time=%.3f ms\n", timestamp, userInput.hostname, userInput.ip.String(), userInput.port, streak, rtt)
+			}
 		}
 	}
 }
 
-func (p *planePrinter) printProbeFail(hostname, ip string, port uint16, streak uint) {
+func (p *planePrinter) printProbeFail(userInput userInput, streak uint) {
 	timestamp := ""
 	if *p.showTimestamp {
 		timestamp = time.Now().Format(timeFormat)
 	}
-	if hostname == "" {
+	if userInput.hostname == "" {
 		if timestamp == "" {
-			fmt.Printf("No reply from %s on port %d TCP_conn=%d\n", ip, port, streak)
+			fmt.Printf("No reply from %s on port %d TCP_conn=%d\n", userInput.ip, userInput.port, streak)
 		} else {
-			fmt.Printf("%s No reply from %s on port %d TCP_conn=%d\n", timestamp, ip, port, streak)
+			fmt.Printf("%s No reply from %s on port %d TCP_conn=%d\n", timestamp, userInput.ip, userInput.port, streak)
 		}
 	} else {
 		if timestamp == "" {
-			fmt.Printf("No reply from %s (%s) on port %d TCP_conn=%d\n", hostname, ip, port, streak)
+			fmt.Printf("No reply from %s (%s) on port %d TCP_conn=%d\n", userInput.hostname, userInput.ip, userInput.port, streak)
 		} else {
-			fmt.Printf("%s No reply from %s (%s) on port %d TCP_conn=%d\n", timestamp, hostname, ip, port, streak)
+			fmt.Printf("%s No reply from %s (%s) on port %d TCP_conn=%d\n", timestamp, userInput.hostname, userInput.ip, userInput.port, streak)
 		}
 	}
 }
@@ -453,6 +485,7 @@ type JSONData struct {
 	// Optional fields below
 
 	Addr                 string           `json:"addr,omitempty"`
+	LocalAddr            string           `json:"local_address,omitempty"`
 	Hostname             string           `json:"hostname,omitempty"`
 	HostnameResolveTries uint             `json:"hostname_resolve_tries,omitempty"`
 	HostnameChanges      []hostnameChange `json:"hostname_changes,omitempty"`
@@ -539,63 +572,71 @@ func (p *jsonPrinter) printStart(hostname string, port uint16) {
 }
 
 // printReply prints TCP probe replies according to our policies in JSON format.
-func (p *jsonPrinter) printProbeSuccess(
-	hostname, ip string,
-	port uint16,
-	streak uint,
-	rtt float32,
-) {
+func (p *jsonPrinter) printProbeSuccess(localAddr string, userInput userInput, streak uint, rtt float32) {
 	var (
 		// for *bool fields
 		f    = false
 		t    = true
 		data = JSONData{
 			Type:                  probeEvent,
-			Hostname:              hostname,
-			Addr:                  ip,
-			Port:                  port,
+			Hostname:              userInput.hostname,
+			Addr:                  userInput.ip.String(),
+			Port:                  userInput.port,
 			Rtt:                   rtt,
 			DestIsIP:              &t,
 			Success:               &t,
 			TotalSuccessfulProbes: streak,
 		}
 	)
+	if userInput.showLocalAddress {
+		data.LocalAddr = localAddr
+	}
 
-	if hostname != "" {
+	if userInput.hostname != "" {
 		data.DestIsIP = &f
-		data.Message = fmt.Sprintf("Reply from %s (%s) on port %d time=%.3f",
-			hostname, ip, port, rtt)
+		if userInput.showLocalAddress {
+			data.Message = fmt.Sprintf("Reply from %s (%s) on port %d using %s time=%.3f ms",
+				userInput.hostname, userInput.ip.String(), userInput.port, localAddr, rtt)
+		} else {
+			data.Message = fmt.Sprintf("Reply from %s (%s) on port %d time=%.3f ms",
+				userInput.hostname, userInput.ip.String(), userInput.port, rtt)
+		}
 	} else {
-		data.Message = fmt.Sprintf("Reply from %s on port %d time=%.3f",
-			ip, port, rtt)
+		if userInput.showLocalAddress {
+			data.Message = fmt.Sprintf("Reply from %s on port %d using %s time=%.3f ms",
+				userInput.ip.String(), userInput.port, localAddr, rtt)
+		} else {
+			data.Message = fmt.Sprintf("Reply from %s on port %d time=%.3f ms",
+				userInput.ip.String(), userInput.port, rtt)
+		}
 	}
 
 	p.print(data)
 }
 
-func (p *jsonPrinter) printProbeFail(hostname, ip string, port uint16, streak uint) {
+func (p *jsonPrinter) printProbeFail(userInput userInput, streak uint) {
 	var (
 		// for *bool fields
 		f    = false
 		t    = true
 		data = JSONData{
 			Type:                    probeEvent,
-			Hostname:                hostname,
-			Addr:                    ip,
-			Port:                    port,
+			Hostname:                userInput.hostname,
+			Addr:                    userInput.ip.String(),
+			Port:                    userInput.port,
 			DestIsIP:                &t,
 			Success:                 &f,
 			TotalUnsuccessfulProbes: streak,
 		}
 	)
 
-	if hostname != "" {
+	if userInput.hostname != "" {
 		data.DestIsIP = &f
 		data.Message = fmt.Sprintf("No reply from %s (%s) on port %d",
-			hostname, ip, port)
+			userInput.hostname, userInput.ip.String(), userInput.port)
 	} else {
 		data.Message = fmt.Sprintf("No reply from %s on port %d",
-			ip, port)
+			userInput.ip.String(), userInput.port)
 	}
 
 	p.print(data)

--- a/statsprinter_test.go
+++ b/statsprinter_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"testing"
 	"time"
@@ -16,15 +17,15 @@ import (
 // of a printer that does nothing.
 type dummyPrinter struct{}
 
-func (fp *dummyPrinter) printStart(_ string, _ uint16)                              {}
-func (fp *dummyPrinter) printProbeFail(_, _ string, _ uint16, _ uint)               {}
-func (fp *dummyPrinter) printRetryingToResolve(_ string)                            {}
-func (fp *dummyPrinter) printTotalDownTime(_ time.Duration)                         {}
-func (fp *dummyPrinter) printStatistics(_ tcping)                                   {}
-func (fp *dummyPrinter) printVersion()                                              {}
-func (fp *dummyPrinter) printInfo(_ string, _ ...interface{})                       {}
-func (fp *dummyPrinter) printError(_ string, _ ...interface{})                      {}
-func (fp *dummyPrinter) printProbeSuccess(_, _ string, _ uint16, _ uint, _ float32) {}
+func (fp *dummyPrinter) printStart(_ string, _ uint16)                                {}
+func (fp *dummyPrinter) printProbeSuccess(_ net.Conn, _ userInput, _ uint, _ float32) {}
+func (fp *dummyPrinter) printProbeFail(_ userInput, _ uint)                           {}
+func (fp *dummyPrinter) printRetryingToResolve(_ string)                              {}
+func (fp *dummyPrinter) printTotalDownTime(_ time.Duration)                           {}
+func (fp *dummyPrinter) printStatistics(_ tcping)                                     {}
+func (fp *dummyPrinter) printVersion()                                                {}
+func (fp *dummyPrinter) printInfo(_ string, _ ...interface{})                         {}
+func (fp *dummyPrinter) printError(_ string, _ ...interface{})                        {}
 
 func TestDurationToString(t *testing.T) {
 	t.Parallel()
@@ -107,52 +108,54 @@ func TestPrintProbeSuccess(t *testing.T) {
 	rtt := float32(15.123)
 
 	testCases := []struct {
-		name           string
-		showTimestamp  bool
-		useHostname    bool
-		expectedOutput string
+		name             string
+		showTimestamp    bool
+		useHostname      bool
+		showLocalAddress bool
+		expectedOutput   string
 	}{
 		{
-			name:           "With hostname, no timestamp",
-			showTimestamp:  false,
-			useHostname:    true,
-			expectedOutput: "Reply from %s (%s) on port %d TCP_conn=%d time=%.3f ms\n",
+			name:             "With hostname, no timestamp",
+			showTimestamp:    false,
+			useHostname:      true,
+			showLocalAddress: false,
+			expectedOutput:   "Reply from %s (%s) on port %d TCP_conn=%d time=%.3f ms\n",
 		},
 		{
-			name:           "With hostname, with timestamp",
-			showTimestamp:  true,
-			useHostname:    true,
-			expectedOutput: "%s Reply from %s (%s) on port %d TCP_conn=%d time=%.3f ms\n",
+			name:             "With hostname, with timestamp",
+			showTimestamp:    true,
+			useHostname:      true,
+			showLocalAddress: false,
+			expectedOutput:   "%s Reply from %s (%s) on port %d TCP_conn=%d time=%.3f ms\n",
 		},
 		{
-			name:           "Without hostname, with timestamp",
-			showTimestamp:  true,
-			useHostname:    false,
-			expectedOutput: "%s Reply from %s on port %d TCP_conn=%d time=%.3f ms\n",
+			name:             "Without hostname, with timestamp",
+			showTimestamp:    true,
+			useHostname:      false,
+			showLocalAddress: false,
+			expectedOutput:   "%s Reply from %s on port %d TCP_conn=%d time=%.3f ms\n",
 		},
 		{
-			name:           "Without hostname, no timestamp",
-			showTimestamp:  false,
-			useHostname:    false,
-			expectedOutput: "Reply from %s on port %d TCP_conn=%d time=%.3f ms\n",
+			name:             "Without hostname, no timestamp",
+			showTimestamp:    false,
+			useHostname:      false,
+			showLocalAddress: false,
+			expectedOutput:   "Reply from %s on port %d TCP_conn=%d time=%.3f ms\n",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			pp := newColorPrinter(&tc.showTimestamp)
+			pp := newPlanePrinter(&tc.showTimestamp)
 
 			read, write, _ := os.Pipe()
 			os.Stdout = write
-			color.SetOutput(write)
-			color.Disable()
 
-			hostname := stats.userInput.hostname
 			if !tc.useHostname {
-				hostname = ""
+				stats.userInput.hostname = ""
 			}
 
-			pp.printProbeSuccess(hostname, stats.userInput.ip.String(), stats.userInput.port, streak, rtt)
+			pp.printProbeSuccess(nil, stats.userInput, streak, rtt)
 
 			write.Close()
 
@@ -167,13 +170,13 @@ func TestPrintProbeSuccess(t *testing.T) {
 			if tc.showTimestamp {
 				timestamp := time.Now().Format("2006-01-02 15:04:05")
 				if tc.useHostname {
-					expected = fmt.Sprintf(tc.expectedOutput, timestamp, hostname, stats.userInput.ip, stats.userInput.port, streak, rtt)
+					expected = fmt.Sprintf(tc.expectedOutput, timestamp, stats.userInput.hostname, stats.userInput.ip, stats.userInput.port, streak, rtt)
 				} else {
 					expected = fmt.Sprintf(tc.expectedOutput, timestamp, stats.userInput.ip, stats.userInput.port, streak, rtt)
 				}
 			} else {
 				if tc.useHostname {
-					expected = fmt.Sprintf(tc.expectedOutput, hostname, stats.userInput.ip, stats.userInput.port, streak, rtt)
+					expected = fmt.Sprintf(tc.expectedOutput, stats.userInput.hostname, stats.userInput.ip, stats.userInput.port, streak, rtt)
 				} else {
 					expected = fmt.Sprintf(tc.expectedOutput, stats.userInput.ip, stats.userInput.port, streak, rtt)
 				}
@@ -231,12 +234,11 @@ func TestPrintProbeFail(t *testing.T) {
 			color.SetOutput(write)
 			color.Disable()
 
-			hostname := stats.userInput.hostname
 			if !tc.useHostname {
-				hostname = ""
+				stats.userInput.hostname = ""
 			}
 
-			pp.printProbeFail(hostname, stats.userInput.ip.String(), stats.userInput.port, streak)
+			pp.printProbeFail(stats.userInput, streak)
 
 			write.Close()
 

--- a/statsprinter_test.go
+++ b/statsprinter_test.go
@@ -100,14 +100,14 @@ func TestDurationToString(t *testing.T) {
 	}
 }
 
-func TestPrintProbeSuccess(t *testing.T) {
-	stats := createTestStats(t)
-	stats.userInput.hostname = "example.com"
-
-	streak := uint(5)
-	rtt := float32(15.123)
-
-	testCases := []struct {
+func getProbeSuccessTests() []struct {
+	name             string
+	showTimestamp    bool
+	useHostname      bool
+	showLocalAddress bool
+	expectedOutput   string
+} {
+	return []struct {
 		name             string
 		showTimestamp    bool
 		useHostname      bool
@@ -142,7 +142,23 @@ func TestPrintProbeSuccess(t *testing.T) {
 			showLocalAddress: false,
 			expectedOutput:   "Reply from %s on port %d TCP_conn=%d time=%.3f ms\n",
 		},
+		{
+			name:             "Without hostname, no timestamp, with show local address",
+			showTimestamp:    false,
+			useHostname:      false,
+			showLocalAddress: true,
+			expectedOutput:   "Reply from %s on port %d using %s TCP_conn=%d time=%.3f ms\n",
+		},
 	}
+}
+
+func TestPrintProbeSuccess(t *testing.T) {
+	testCases := getProbeSuccessTests()
+	stats := createTestStats(t)
+	stats.userInput.hostname = "example.com"
+	streak := uint(5)
+	rtt := float32(15.123)
+	localAddr := "127.0.0.1:4567"
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/tcping.go
+++ b/tcping.go
@@ -38,12 +38,12 @@ type printer interface {
 	// printProbeSuccess should print a message after each successful probe.
 	// hostname could be empty, meaning it's pinging an address.
 	// streak is the number of successful consecutive probes.
-	printProbeSuccess(hostname, ip string, port uint16, streak uint, rtt float32)
+	printProbeSuccess(localAddr string, userInput userInput, streak uint, rtt float32)
 
 	// printProbeFail should print a message after each failed probe.
 	// hostname could be empty, meaning it's pinging an address.
 	// streak is the number of successful consecutive probes.
-	printProbeFail(hostname, ip string, port uint16, streak uint)
+	printProbeFail(userInput userInput, streak uint)
 
 	// printRetryingToResolve should print a message with the hostname
 	// it is trying to resolve an ip for.
@@ -116,6 +116,7 @@ type userInput struct {
 	useIPv6                  bool
 	shouldRetryResolve       bool
 	showFailuresOnly         bool
+	showLocalAddress         bool
 }
 
 type genericUserInputArgs struct {
@@ -125,6 +126,7 @@ type genericUserInputArgs struct {
 	secondsBetweenProbes *float64
 	intName              *string
 	showFailuresOnly     *bool
+	showLocalAddress     *bool
 	args                 []string
 }
 
@@ -315,6 +317,8 @@ func setGenericArgs(tcping *tcping, genericArgs genericUserInputArgs) {
 	}
 
 	tcping.userInput.showFailuresOnly = *genericArgs.showFailuresOnly
+
+	tcping.userInput.showLocalAddress = *genericArgs.showLocalAddress
 }
 
 // processUserInput gets and validate user input
@@ -333,6 +337,7 @@ func processUserInput(tcping *tcping) {
 	timeout := flag.Float64("t", 1, "time to wait for a response, in seconds. Real number allowed. 0 means infinite timeout.")
 	outputDB := flag.String("db", "", "path and file name to store tcping output to sqlite database.")
 	interfaceName := flag.String("I", "", "interface name or address.")
+	showLocalAddress := flag.Bool("show-local-address", false, "Show source address and port used for probe.")
 	showFailuresOnly := flag.Bool("show-failures-only", false, "Show only the failed probes.")
 	showHelp := flag.Bool("h", false, "show help message.")
 
@@ -382,6 +387,7 @@ func processUserInput(tcping *tcping) {
 		secondsBetweenProbes: secondsBetweenProbes,
 		intName:              interfaceName,
 		showFailuresOnly:     showFailuresOnly,
+		showLocalAddress:     showLocalAddress,
 		args:                 args,
 	}
 
@@ -802,15 +808,13 @@ func (t *tcping) handleConnError(connTime time.Time, elapsed time.Duration) {
 	t.ongoingUnsuccessfulProbes += 1
 
 	t.printProbeFail(
-		t.userInput.hostname,
-		t.userInput.ip.String(),
-		t.userInput.port,
+		t.userInput,
 		t.ongoingUnsuccessfulProbes,
 	)
 }
 
 // handleConnSuccess processes successful probes
-func (t *tcping) handleConnSuccess(rtt float32, connTime time.Time, elapsed time.Duration) {
+func (t *tcping) handleConnSuccess(localAddr string, rtt float32, connTime time.Time, elapsed time.Duration) {
 	if t.destWasDown {
 		t.startOfUptime = connTime
 		downtime := t.startOfUptime.Sub(t.startOfDowntime)
@@ -834,9 +838,8 @@ func (t *tcping) handleConnSuccess(rtt float32, connTime time.Time, elapsed time
 
 	if !t.userInput.showFailuresOnly {
 		t.printProbeSuccess(
-			t.userInput.hostname,
-			t.userInput.ip.String(),
-			t.userInput.port,
+			localAddr,
+			t.userInput,
 			t.ongoingSuccessfulProbes,
 			rtt,
 		)
@@ -865,7 +868,7 @@ func tcpProbe(tcping *tcping) {
 	if err != nil {
 		tcping.handleConnError(connStart, elapsed)
 	} else {
-		tcping.handleConnSuccess(rtt, connStart, elapsed)
+		tcping.handleConnSuccess(conn.LocalAddr().String(), rtt, connStart, elapsed)
 		conn.Close()
 	}
 	<-tcping.ticker.C


### PR DESCRIPTION
## Summary

- implement local ip address and port display option
- remove unused printer arguments of `db` printer
- add docs for `show-local-address` flag
- move probe success test conditions to their own function to improve readability
- replace color printer with plane printer in tests

Closes #249 