### PR TITLE
Fix `go install` installation instructions, and mention minimum go version

### DIFF
--- a/README.cn.md
+++ b/README.cn.md
@@ -109,7 +109,7 @@
 - 使用 `go install` 安装：
 
   ```bash
-  go install github.com/pouriyajamshidi/tcping@latest
+  go install github.com/pouriyajamshidi/tcping/v2@latest
   ```
 
 - 使用 `brew` 安装：

--- a/README.md
+++ b/README.md
@@ -103,8 +103,10 @@ When the download is complete, head to the [usage](#usage) section.
 
 - Install using `go install`:
 
+  This requires at least go version `1.23.1`
+
   ```bash
-  go install github.com/pouriyajamshidi/tcping@latest
+  go install github.com/pouriyajamshidi/tcping/v2@latest
   ```
 
 - Install using `brew`:


### PR DESCRIPTION
## Describe your changes

Fixes `go install` documentation, as discussed in #262 

I updated the command for the chinese README as well, but was unable to add the sentence mentioning the minimum version.

If someone wants to provide the translation so I can add it to this PR, feel free to ; otherwise, the error message during `go install` is probably clear enough that it's fine not explicitly documenting the version constraint in the first place.

## Issue ticket number and link

Closes https://github.com/pouriyajamshidi/tcping/issues/262

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added tests.
- [ ] I have run `make check` and there are no failures.

## Type of change

Documentation fix.