### PR TITLE
fix: represent latency as empty string in csv printer failed probes

### DIFF
--- a/csv.go
+++ b/csv.go
@@ -142,7 +142,7 @@ func (cp *csvPrinter) printStart(hostname string, port uint16) {
 func (cp *csvPrinter) printProbeSuccess(localAddr string, userInput userInput, streak uint, rtt float32) {
 	hostname := userInput.hostname
 	if hostname == "" {
-		hostname = "-"
+		hostname = ""
 	}
 
 	record := []string{
@@ -166,7 +166,7 @@ func (cp *csvPrinter) printProbeSuccess(localAddr string, userInput userInput, s
 func (cp *csvPrinter) printProbeFail(userInput userInput, streak uint) {
 	hostname := userInput.hostname
 	if hostname == "" {
-		hostname = "-"
+		hostname = ""
 	}
 
 	record := []string{
@@ -191,10 +191,10 @@ func (cp *csvPrinter) printRetryingToResolve(hostname string) {
 	record := []string{
 		"Resolving",
 		hostname,
-		"-",
-		"-",
-		"-",
-		"-",
+		"",
+		"",
+		"",
+		"",
 	}
 
 	if err := cp.writeRecord(record); err != nil {

--- a/csv.go
+++ b/csv.go
@@ -175,7 +175,11 @@ func (cp *csvPrinter) printProbeFail(userInput userInput, streak uint) {
 		userInput.ip.String(),
 		fmt.Sprint(userInput.port),
 		fmt.Sprint(streak),
-		"-",
+		"",
+	}
+
+	if *cp.showLocalAddress {
+		record = append(record, "")
 	}
 
 	if err := cp.writeRecord(record); err != nil {
@@ -203,7 +207,7 @@ func (cp *csvPrinter) printError(format string, args ...any) {
 }
 
 func (cp *csvPrinter) writeStatsHeader() error {
-    
+
 	headers := []string{
 		"Metric",
 		"Value",

--- a/csv.go
+++ b/csv.go
@@ -141,9 +141,6 @@ func (cp *csvPrinter) printStart(hostname string, port uint16) {
 
 func (cp *csvPrinter) printProbeSuccess(localAddr string, userInput userInput, streak uint, rtt float32) {
 	hostname := userInput.hostname
-	if hostname == "" {
-		hostname = ""
-	}
 
 	record := []string{
 		"Reply",

--- a/csv.go
+++ b/csv.go
@@ -162,9 +162,6 @@ func (cp *csvPrinter) printProbeSuccess(localAddr string, userInput userInput, s
 
 func (cp *csvPrinter) printProbeFail(userInput userInput, streak uint) {
 	hostname := userInput.hostname
-	if hostname == "" {
-		hostname = ""
-	}
 
 	record := []string{
 		"No reply",


### PR DESCRIPTION
# Important

**Please provide the requested parameters below to help us review your pull request.**

**Pull requests without a body or explanation will be rejected.**
I think latency metric should be an empty string in case of failed probes in the csv printer.
This PR also addresses adding an empty string in case show-local-address option was enabled.

## Describe your changes

## Issue ticket number and link

Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added tests.
- [ ] I have run `make check` and there are no failures.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
