### PR TITLE
Refactor/csv printer

### DIFF
--- a/csv.go
+++ b/csv.go
@@ -143,7 +143,7 @@ func (cp *csvPrinter) writeRecord(record []string) error {
 }
 
 func (cp *csvPrinter) printStart(hostname string, port uint16) {
-	fmt.Printf("TCPing results being written to: %s\n", cp.probeFilename)
+	fmt.Printf("TCPing results for %s on port %d being written to: %s\n", hostname, port, cp.probeFilename)
 }
 
 func (cp *csvPrinter) printProbeSuccess(localAddr string, userInput userInput, streak uint, rtt float32) {

--- a/csv.go
+++ b/csv.go
@@ -5,20 +5,21 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"strings"
 	"time"
 )
 
 type csvPrinter struct {
-	writer           *csv.Writer
-	file             *os.File
-	dataFilename     string
-	headerDone       bool
-	showTimestamp    *bool
-	showLocalAddress *bool
+	probeWriter      *csv.Writer
 	statsWriter      *csv.Writer
+	probeFile        *os.File
 	statsFile        *os.File
 	statsFilename    string
+	probeFilename    string
+	headerDone       bool
 	statsHeaderDone  bool
+	showTimestamp    *bool
+	showLocalAddress *bool
 	cleanup          func()
 }
 
@@ -33,40 +34,44 @@ const (
 	colLocalAddress = "Local Address"
 )
 
-func ensureCSVExtension(filename string) string {
-	if len(filename) > 4 && filename[len(filename)-4:] == ".csv" {
+const (
+	filePermission os.FileMode = 0644
+)
+
+func addCSVExtension(filename string, withStats bool) string {
+	if withStats {
+		return strings.Split(filename, ".")[0] + "_stats.csv"
+	}
+	if strings.HasSuffix(filename, ".csv") {
 		return filename
 	}
 	return filename + ".csv"
 }
 
-func newCSVPrinter(dataFilename string, showTimestamp *bool, showLocalAddress *bool) (*csvPrinter, error) {
-	// Ensure .csv extension for dataFilename
-	dataFilename = ensureCSVExtension(dataFilename)
+func newCSVPrinter(filename string, showTimestamp *bool, showLocalAddress *bool) (*csvPrinter, error) {
+	filename = addCSVExtension(filename, false)
 
-	// Open the data file with the os.O_TRUNC flag to truncate it
-	file, err := os.OpenFile(dataFilename, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
+	file, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, filePermission)
 	if err != nil {
 		return nil, fmt.Errorf("error creating data CSV file: %w", err)
 	}
 
-	// Append _stats before the .csv extension for statsFilename
-	statsFilename := dataFilename[:len(dataFilename)-4] + "_stats.csv"
+	statsFilename := addCSVExtension(filename, true)
 	cp := &csvPrinter{
-		writer:           csv.NewWriter(file),
-		file:             file,
-		dataFilename:     dataFilename,
+		probeWriter:      csv.NewWriter(file),
+		probeFile:        file,
+		probeFilename:    filename,
 		statsFilename:    statsFilename,
 		showTimestamp:    showTimestamp,
 		showLocalAddress: showLocalAddress,
 	}
 
 	cp.cleanup = func() {
-		if cp.writer != nil {
-			cp.writer.Flush()
+		if cp.probeWriter != nil {
+			cp.probeWriter.Flush()
 		}
-		if cp.file != nil {
-			cp.file.Close()
+		if cp.probeFile != nil {
+			cp.probeFile.Close()
 		}
 		if cp.statsWriter != nil {
 			cp.statsWriter.Flush()
@@ -97,22 +102,23 @@ func (cp *csvPrinter) writeHeader() error {
 		headers = append(headers, colTimestamp)
 	}
 
-	if err := cp.writer.Write(headers); err != nil {
+	if err := cp.probeWriter.Write(headers); err != nil {
 		return fmt.Errorf("failed to write headers: %w", err)
 	}
 
-	cp.writer.Flush()
-	return cp.writer.Error()
+	cp.probeWriter.Flush()
+
+	return cp.probeWriter.Error()
 }
 
 func (cp *csvPrinter) writeRecord(record []string) error {
-	if _, err := os.Stat(cp.dataFilename); os.IsNotExist(err) {
-		file, err := os.OpenFile(cp.dataFilename, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	if _, err := os.Stat(cp.probeFilename); os.IsNotExist(err) {
+		file, err := os.OpenFile(cp.probeFilename, os.O_CREATE|os.O_WRONLY|os.O_APPEND, filePermission)
 		if err != nil {
 			return fmt.Errorf("failed to recreate data CSV file: %w", err)
 		}
-		cp.file = file
-		cp.writer = csv.NewWriter(file)
+		cp.probeFile = file
+		cp.probeWriter = csv.NewWriter(file)
 		cp.headerDone = false
 	}
 
@@ -127,24 +133,23 @@ func (cp *csvPrinter) writeRecord(record []string) error {
 		record = append(record, time.Now().Format(timeFormat))
 	}
 
-	if err := cp.writer.Write(record); err != nil {
+	if err := cp.probeWriter.Write(record); err != nil {
 		return fmt.Errorf("failed to write record: %w", err)
 	}
 
-	cp.writer.Flush()
-	return cp.writer.Error()
+	cp.probeWriter.Flush()
+
+	return cp.probeWriter.Error()
 }
 
 func (cp *csvPrinter) printStart(hostname string, port uint16) {
-	fmt.Printf("TCPing results being written to: %s\n", cp.dataFilename)
+	fmt.Printf("TCPing results being written to: %s\n", cp.probeFilename)
 }
 
 func (cp *csvPrinter) printProbeSuccess(localAddr string, userInput userInput, streak uint, rtt float32) {
-	hostname := userInput.hostname
-
 	record := []string{
 		"Reply",
-		hostname,
+		userInput.hostname,
 		userInput.ip.String(),
 		fmt.Sprint(userInput.port),
 		fmt.Sprint(streak),
@@ -156,16 +161,14 @@ func (cp *csvPrinter) printProbeSuccess(localAddr string, userInput userInput, s
 	}
 
 	if err := cp.writeRecord(record); err != nil {
-		cp.printError("Failed to write success record: %v", err)
+		cp.printError("failed to write success record: %v", err)
 	}
 }
 
 func (cp *csvPrinter) printProbeFail(userInput userInput, streak uint) {
-	hostname := userInput.hostname
-
 	record := []string{
 		"No reply",
-		hostname,
+		userInput.hostname,
 		userInput.ip.String(),
 		fmt.Sprint(userInput.port),
 		fmt.Sprint(streak),
@@ -177,7 +180,7 @@ func (cp *csvPrinter) printProbeFail(userInput userInput, streak uint) {
 	}
 
 	if err := cp.writeRecord(record); err != nil {
-		cp.printError("Failed to write failure record: %v", err)
+		cp.printError("failed to write failure record: %v", err)
 	}
 }
 
@@ -192,7 +195,7 @@ func (cp *csvPrinter) printRetryingToResolve(hostname string) {
 	}
 
 	if err := cp.writeRecord(record); err != nil {
-		cp.printError("Failed to write resolve record: %v", err)
+		cp.printError("failed to write resolve record: %v", err)
 	}
 }
 
@@ -212,12 +215,13 @@ func (cp *csvPrinter) writeStatsHeader() error {
 	}
 
 	cp.statsWriter.Flush()
+
 	return cp.statsWriter.Error()
 }
 
 func (cp *csvPrinter) writeStatsRecord(record []string) error {
 	if _, err := os.Stat(cp.statsFilename); os.IsNotExist(err) {
-		statsFile, err := os.OpenFile(cp.statsFilename, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+		statsFile, err := os.OpenFile(cp.statsFilename, os.O_CREATE|os.O_WRONLY|os.O_APPEND, filePermission)
 		if err != nil {
 			return fmt.Errorf("failed to recreate statistics CSV file: %w", err)
 		}
@@ -226,7 +230,6 @@ func (cp *csvPrinter) writeStatsRecord(record []string) error {
 		cp.statsHeaderDone = false
 	}
 
-	// Write header if not done
 	if !cp.statsHeaderDone {
 		if err := cp.writeStatsHeader(); err != nil {
 			return err
@@ -239,15 +242,15 @@ func (cp *csvPrinter) writeStatsRecord(record []string) error {
 	}
 
 	cp.statsWriter.Flush()
+
 	return cp.statsWriter.Error()
 }
 
 func (cp *csvPrinter) printStatistics(t tcping) {
-	// Initialize stats file if not already done
 	if cp.statsFile == nil {
-		statsFile, err := os.OpenFile(cp.statsFilename, os.O_CREATE|os.O_WRONLY|os.O_APPEND|os.O_TRUNC, 0644)
+		statsFile, err := os.OpenFile(cp.statsFilename, os.O_CREATE|os.O_WRONLY|os.O_APPEND|os.O_TRUNC, filePermission)
 		if err != nil {
-			cp.printError("Failed to create statistics CSV file: %v", err)
+			cp.printError("failed to create statistics CSV file: %v", err)
 			return
 		}
 		cp.statsFile = statsFile
@@ -262,7 +265,7 @@ func (cp *csvPrinter) printStatistics(t tcping) {
 	}
 
 	// Collect statistics data
-	timestamp := time.Now().Format(time.RFC3339)
+	timestamp := time.Now().Format(timeFormat)
 	statistics := [][]string{
 		{"Timestamp", timestamp},
 		{"Total Packets", fmt.Sprint(totalPackets)},
@@ -333,15 +336,13 @@ func (cp *csvPrinter) printStatistics(t tcping) {
 	durationTime := time.Time{}.Add(t.totalDowntime + t.totalUptime)
 	statistics = append(statistics, []string{"Duration (HH:MM:SS)", durationTime.Format(hourFormat)})
 
-	// Write statistics to CSV
 	for _, record := range statistics {
 		if err := cp.writeStatsRecord(record); err != nil {
-			cp.printError("Failed to write statistics record: %v", err)
+			cp.printError("failed to write statistics record: %v", err)
 			return
 		}
 	}
 
-	// Print the message only if statistics are written
 	fmt.Printf("TCPing statistics written to: %s\n", cp.statsFilename)
 }
 

--- a/csv_test.go
+++ b/csv_test.go
@@ -1,132 +1,132 @@
 package main
 
 import (
-    "encoding/csv"
-    "os"
-    "testing"
-    "time"
+	"encoding/csv"
+	"os"
+	"testing"
+	"time"
 
-    "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestNewCSVPrinter(t *testing.T) {
-    dataFilename := "test_data.csv"
-    showTimestamp := true
-    showLocalAddress := true
+	dataFilename := "test_data.csv"
+	showTimestamp := true
+	showLocalAddress := true
 
-    cp, err := newCSVPrinter(dataFilename, &showTimestamp, &showLocalAddress)
-    assert.NoError(t, err)
-    assert.NotNil(t, cp)
-    assert.Equal(t, dataFilename, cp.dataFilename)
-    assert.Equal(t, dataFilename[:len(dataFilename)-4]+"_stats.csv", cp.statsFilename)
+	cp, err := newCSVPrinter(dataFilename, &showTimestamp, &showLocalAddress)
+	assert.NoError(t, err)
+	assert.NotNil(t, cp)
+	assert.Equal(t, dataFilename, cp.probeFilename)
+	assert.Equal(t, dataFilename[:len(dataFilename)-4]+"_stats.csv", cp.statsFilename)
 
-    cp.cleanup()
-    os.Remove(dataFilename)
-    os.Remove(cp.statsFilename)
+	cp.cleanup()
+	os.Remove(dataFilename)
+	os.Remove(cp.statsFilename)
 }
 
 func TestWriteRecord(t *testing.T) {
-    dataFilename := "test_data.csv"
-    showTimestamp := false
-    showLocalAddress := true
+	dataFilename := "test_data.csv"
+	showTimestamp := false
+	showLocalAddress := true
 
-    cp, err := newCSVPrinter(dataFilename, &showTimestamp, &showLocalAddress)
-    assert.NoError(t, err)
-    assert.NotNil(t, cp)
+	cp, err := newCSVPrinter(dataFilename, &showTimestamp, &showLocalAddress)
+	assert.NoError(t, err)
+	assert.NotNil(t, cp)
 
-    record := []string{"Success", "hostname", "127.0.0.1", "80", "1", "10.123", "localAddr"}
-    err = cp.writeRecord(record)
-    assert.NoError(t, err)
+	record := []string{"Success", "hostname", "127.0.0.1", "80", "1", "10.123", "localAddr"}
+	err = cp.writeRecord(record)
+	assert.NoError(t, err)
 
-    // Verify the record is written
-    file, err := os.Open(dataFilename)
-    assert.NoError(t, err)
-    defer file.Close()
+	// Verify the record is written
+	file, err := os.Open(dataFilename)
+	assert.NoError(t, err)
+	defer file.Close()
 
-    reader := csv.NewReader(file)
-    headers, err := reader.Read()
-    assert.NoError(t, err)
-    assert.Equal(t, []string{"Status", "Hostname", "IP", "Port", "TCP_Conn", "Latency(ms)", "Local Address"}, headers)
+	reader := csv.NewReader(file)
+	headers, err := reader.Read()
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"Status", "Hostname", "IP", "Port", "TCP_Conn", "Latency(ms)", "Local Address"}, headers)
 
-    readRecord, err := reader.Read()
-    assert.NoError(t, err)
-    assert.Equal(t, record, readRecord)
+	readRecord, err := reader.Read()
+	assert.NoError(t, err)
+	assert.Equal(t, record, readRecord)
 
-    // Cleanup
-    cp.cleanup()
-    os.Remove(dataFilename)
-    os.Remove(cp.statsFilename)
+	// Cleanup
+	cp.cleanup()
+	os.Remove(dataFilename)
+	os.Remove(cp.statsFilename)
 }
 
 func TestWriteStatistics(t *testing.T) {
-    dataFilename := "test_data.csv"
-    showTimestamp := true
-    showLocalAddress := false
+	dataFilename := "test_data.csv"
+	showTimestamp := true
+	showLocalAddress := false
 
-    cp, err := newCSVPrinter(dataFilename, &showTimestamp, &showLocalAddress)
-    assert.NoError(t, err)
-    assert.NotNil(t, cp)
+	cp, err := newCSVPrinter(dataFilename, &showTimestamp, &showLocalAddress)
+	assert.NoError(t, err)
+	assert.NotNil(t, cp)
 
-    tcping := tcping{
-        totalSuccessfulProbes:   1,
-        totalUnsuccessfulProbes: 0,
-        lastSuccessfulProbe:     time.Now(),
-        startTime:               time.Now(),
-    }
+	tcping := tcping{
+		totalSuccessfulProbes:   1,
+		totalUnsuccessfulProbes: 0,
+		lastSuccessfulProbe:     time.Now(),
+		startTime:               time.Now(),
+	}
 
-    cp.printStatistics(tcping)
+	cp.printStatistics(tcping)
 
-    statsFile, err := os.Open(cp.statsFilename)
-    assert.NoError(t, err)
-    defer statsFile.Close()
+	statsFile, err := os.Open(cp.statsFilename)
+	assert.NoError(t, err)
+	defer statsFile.Close()
 
-    reader := csv.NewReader(statsFile)
-    headers, err := reader.Read()
-    assert.NoError(t, err)
-    assert.Equal(t, []string{"Metric", "Value"}, headers)
+	reader := csv.NewReader(statsFile)
+	headers, err := reader.Read()
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"Metric", "Value"}, headers)
 
-    for {
-        record, err := reader.Read()
-        if err != nil {
-            break
-        }
-        assert.NotEmpty(t, record)
-    }
+	for {
+		record, err := reader.Read()
+		if err != nil {
+			break
+		}
+		assert.NotEmpty(t, record)
+	}
 
-    cp.cleanup()
-    os.Remove(dataFilename)
-    os.Remove(cp.statsFilename)
+	cp.cleanup()
+	os.Remove(dataFilename)
+	os.Remove(cp.statsFilename)
 }
 
 func TestCleanup(t *testing.T) {
-    dataFilename := "test_data.csv"
-    showTimestamp := true
-    showLocalAddress := false
+	dataFilename := "test_data.csv"
+	showTimestamp := true
+	showLocalAddress := false
 
-    cp, err := newCSVPrinter(dataFilename, &showTimestamp, &showLocalAddress)
-    assert.NoError(t, err)
-    assert.NotNil(t, cp)
+	cp, err := newCSVPrinter(dataFilename, &showTimestamp, &showLocalAddress)
+	assert.NoError(t, err)
+	assert.NotNil(t, cp)
 
-    // Call printStatistics to ensure the stats file is created
-    tcping := tcping{
-        totalSuccessfulProbes:   1,
-        totalUnsuccessfulProbes: 0,
-        lastSuccessfulProbe:     time.Now(),
-        startTime:               time.Now(),
-    }
-    cp.printStatistics(tcping)
+	// Call printStatistics to ensure the stats file is created
+	tcping := tcping{
+		totalSuccessfulProbes:   1,
+		totalUnsuccessfulProbes: 0,
+		lastSuccessfulProbe:     time.Now(),
+		startTime:               time.Now(),
+	}
+	cp.printStatistics(tcping)
 
-    // Perform cleanup
-    cp.cleanup()
+	// Perform cleanup
+	cp.cleanup()
 
-    // Verify files are closed and flushed
-    _, err = os.Stat(dataFilename)
-    assert.NoError(t, err)
+	// Verify files are closed and flushed
+	_, err = os.Stat(dataFilename)
+	assert.NoError(t, err)
 
-    _, err = os.Stat(cp.statsFilename)
-    assert.NoError(t, err)
+	_, err = os.Stat(cp.statsFilename)
+	assert.NoError(t, err)
 
-    // Cleanup files
-    os.Remove(dataFilename)
-    os.Remove(cp.statsFilename)
+	// Cleanup files
+	os.Remove(dataFilename)
+	os.Remove(cp.statsFilename)
 }

--- a/tcping.go
+++ b/tcping.go
@@ -355,7 +355,6 @@ func processUserInput(tcping *tcping) {
 	showFailuresOnly := flag.Bool("show-failures-only", false, "Show only the failed probes.")
 	showHelp := flag.Bool("h", false, "show help message.")
 
-
 	flag.CommandLine.Usage = usage
 
 	permuteArgs(os.Args[1:])

--- a/tcping.go
+++ b/tcping.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
 	"github.com/google/go-github/v45/github"
 )
 
@@ -239,6 +240,7 @@ func setPrinter(tcping *tcping, outputJSON, prettyJSON *bool, noColor *bool, tim
 		colorRed("--pretty has no effect without the -j flag.")
 		usage()
 	}
+
 	if *outputJSON {
 		tcping.printer = newJSONPrinter(*prettyJSON)
 	} else if *outputDb != "" {


### PR DESCRIPTION
## Summary

- fix memory alignment of csvPrinter
- rename fields in csvPrinter struct to better show their intent
- use strings package for a better CSV file handling instead of slicing hacks
- remove unnecessary variables
- announce hostname and port in printStart
- use filePermission constant instead of hardcoded value
- use timeFormat const instead of RFC3339 -- similar to the rest of the program
- stick to lower-case in reporting errors -- similar to other ones in the file
- remove unnecessary comments
- format csv_test file
- minor newline adjustments for better readability