### PR TITLE
Fix/name resolution with 4 flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v2.x.x - Unreleased
 
+- bug: fix name resolution in static builds with `-4` flag causing name resolution failures due to _IPv4-mapped IPv6 addresses_
 - refactor: rename plane to plain printer
 - CI: apply **Revive** suggestions
 - CI: add **Revive** to CI

--- a/tcping.go
+++ b/tcping.go
@@ -616,6 +616,10 @@ func selectResolvedIP(tcping *tcping, ipAddrs []netip.Addr) netip.Addr {
 			if ip.Is4() {
 				ipList = append(ipList, ip)
 			}
+			// static builds (CGO=0) return IPv4-mapped IPv6 address
+			if ip.Is4In6() {
+				ipList = append(ipList, ip.Unmap())
+			}
 		}
 
 		if len(ipList) == 0 {


### PR DESCRIPTION
## Summary

fix name resolution failure with `-4` flag in **static** builds due to the way Go handles _IPv4-mapped IPv6 addresses_

Closes #299 