### PR TITLE
update for release v2.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,9 @@
 # Changelog
 
-## v2.x.x - Unreleased
+## v2.7.1 - 2025-01-26
 
 - release: add tcping to [WinGet](https://learn.microsoft.com/en-us/windows/package-manager/winget) [#113](https://github.com/pouriyajamshidi/tcping/issues/113)
 - bug: fix name resolution in static builds with `-4` flag causing name resolution failures due to _IPv4-mapped IPv6 addresses_
-- refactor: rename plane to plain printer
 - CI: apply **Revive** suggestions
 - CI: add **Revive** to CI
 - CI: add **Revive** config


### PR DESCRIPTION
## Summary

- release: add tcping to [WinGet](https://learn.microsoft.com/en-us/windows/package-manager/winget) [#113](https://github.com/pouriyajamshidi/tcping/issues/113)
- bug: fix name resolution in static builds with `-4` flag causing name resolution failures due to _IPv4-mapped IPv6 addresses_
- CI: apply **Revive** suggestions
- CI: add **Revive** to CI
- CI: add **Revive** config
- documents: revamp and simplify the README file
- documents: update the Chinese translation thanks to @edwinjhlee