### PR TITLE
release 2.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v2.8.0 - 2026-05-11
+
+- feat: add a _non-interactive_ mode through `--non-interactive` flag so that tcping can run in the background using `nohup` or `disown`
+- feat: add support for `host:port` format in command arguments in [362](https://github.com/pouriyajamshidi/tcping/pull/362) thanks to @bingoohuang
+- fix: omit printing the IP address twice when the given target is an IP address itself
+- fix: add missing comma separator in no-color statistics output in [376](https://github.com/pouriyajamshidi/tcping/issues/376) thanks to @clarabennettdev
+- fix: version typo resulting in erroneous update message raised in [313](https://github.com/pouriyajamshidi/tcping/issues/313)
+- build: bump Golang base image to `1.26.3-alpine3.23`
+- documents: fix typo in the Chinese README in [386](https://github.com/pouriyajamshidi/tcping/pull/386) thanks to @peeweep
+- documents: clarify the difference between static and dynamic binaries in README raised in [357](https://github.com/pouriyajamshidi/tcping/issues/357)
+
 ## v2.7.1 - 2025-01-26
 
 - release: add tcping to [WinGet](https://learn.microsoft.com/en-us/windows/package-manager/winget) [#113](https://github.com/pouriyajamshidi/tcping/issues/113)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Build stage
 ##################################################
-FROM docker.io/golang:1.24.10-alpine3.22 AS build
+FROM docker.io/golang:1.26.3-alpine3.23 AS build
 
 WORKDIR /build
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 
 # Meta
 SHELL := /bin/bash
-VERSION := 2.7.1
+VERSION := 2.8.0
 MAINTAINER := https://github.com/pouriyajamshidi
 DESCRIPTION := Ping TCP ports using tcping. Inspired by Linux's ping utility. Written in Go
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ Check out the [demos](#demos) to get a look and feel of **tcping**.
 
 We offer prebuilt binaries for various operating systems ([Windows](#windows), [Linux](#linux---debian-and-derivatives), [macOS](#macos), [Docker](#alternative-ways)) and architectures (_amd64_, _arm64_), which can be found on the [release page](https://github.com/pouriyajamshidi/tcping/releases/latest/).
 
+There are static and dynamic versions available. In simple terms, static binaries include all needed code inside one file, while dynamic binaries load some code from shared operating system libraries when they run.
+
 Once you are done with the download and installation, head to the [usage](#usage) section.
 
 ### Windows
@@ -193,7 +195,7 @@ These are some additional ways in which **tcping** can be installed:
 tcping www.example.com 443
 ```
 
-2. You can also use the `host:port` format for convenience (this will be available in version 3):
+1. You can also use the `host:port` format for convenience:
 
 ```bash
 tcping www.example.com:443
@@ -297,6 +299,7 @@ The following flags are available to control the behavior of **tcping**:
 | `-u`                    | Check for updates                                                                                                 |
 | `--show-failures-only`  | Only show probe failures and omit printing probe success messages                                                 |
 | `--show-source-address` | Show the source IP address and port used for probes                                                               |
+| `--non-interactive`     | Run in background mode. e.g. `nohup` or `disown`                                                                  |
 
 > [!TIP]
 > Without specifying the `-4` and `-6` flags, tcping will randomly select an IP address based on DNS lookups.

--- a/statsprinter.go
+++ b/statsprinter.go
@@ -189,15 +189,32 @@ func (p *colorPrinter) printProbeSuccess(sourceAddr string, userInput userInput,
 	} else {
 		if timestamp == "" {
 			if userInput.showSourceAddress {
-				colorLightGreen("Reply from %s (%s) on port %d using %s TCP_conn=%d time=%.3f ms\n", userInput.hostname, userInput.ip.String(), userInput.port, sourceAddr, streak, rtt)
+				if userInput.hostname == userInput.ip.String() {
+					colorLightGreen("Reply from %s on port %d using %s TCP_conn=%d time=%.3f ms\n", userInput.hostname, userInput.port, sourceAddr, streak, rtt)
+				} else {
+					colorLightGreen("Reply from %s (%s) on port %d using %s TCP_conn=%d time=%.3f ms\n", userInput.hostname, userInput.ip.String(), userInput.port, sourceAddr, streak, rtt)
+				}
 			} else {
-				colorLightGreen("Reply from %s (%s) on port %d TCP_conn=%d time=%.3f ms\n", userInput.hostname, userInput.ip.String(), userInput.port, streak, rtt)
+				if userInput.hostname == userInput.ip.String() {
+					colorLightGreen("Reply from %s on port %d TCP_conn=%d time=%.3f ms\n", userInput.hostname, userInput.port, streak, rtt)
+				} else {
+					colorLightGreen("Reply from %s (%s) on port %d TCP_conn=%d time=%.3f ms\n", userInput.hostname, userInput.ip.String(), userInput.port, streak, rtt)
+				}
 			}
 		} else {
 			if userInput.showSourceAddress {
-				colorLightGreen("%s Reply from %s (%s) on port %d using %s TCP_conn=%d time=%.3f ms\n", timestamp, userInput.hostname, userInput.ip.String(), userInput.port, sourceAddr, streak, rtt)
+				if userInput.hostname == userInput.ip.String() {
+					colorLightGreen("%s Reply from %s on port %d using %s TCP_conn=%d time=%.3f ms\n", timestamp, userInput.hostname, userInput.port, sourceAddr, streak, rtt)
+				} else {
+					colorLightGreen("%s Reply from %s (%s) on port %d using %s TCP_conn=%d time=%.3f ms\n", timestamp,
+						userInput.hostname, userInput.ip.String(), userInput.port, sourceAddr, streak, rtt)
+				}
 			} else {
-				colorLightGreen("%s Reply from %s (%s) on port %d TCP_conn=%d time=%.3f ms\n", timestamp, userInput.hostname, userInput.ip.String(), userInput.port, streak, rtt)
+				if userInput.hostname == userInput.ip.String() {
+					colorLightGreen("%s Reply from %s on port %d TCP_conn=%d time=%.3f ms\n", timestamp, userInput.hostname, userInput.port, streak, rtt)
+				} else {
+					colorLightGreen("%s Reply from %s (%s) on port %d TCP_conn=%d time=%.3f ms\n", timestamp, userInput.hostname, userInput.ip.String(), userInput.port, streak, rtt)
+				}
 			}
 		}
 	}
@@ -372,15 +389,31 @@ func (p *plainPrinter) printProbeSuccess(sourceAddr string, userInput userInput,
 	} else {
 		if timestamp == "" {
 			if userInput.showSourceAddress {
-				fmt.Printf("Reply from %s (%s) on port %d using %s TCP_conn=%d time=%.3f ms\n", userInput.hostname, userInput.ip.String(), userInput.port, sourceAddr, streak, rtt)
+				if userInput.hostname == userInput.ip.String() {
+					fmt.Printf("Reply from %s on port %d using %s TCP_conn=%d time=%.3f ms\n", userInput.hostname, userInput.port, sourceAddr, streak, rtt)
+				} else {
+					fmt.Printf("Reply from %s (%s) on port %d using %s TCP_conn=%d time=%.3f ms\n", userInput.hostname, userInput.ip.String(), userInput.port, sourceAddr, streak, rtt)
+				}
 			} else {
-				fmt.Printf("Reply from %s (%s) on port %d TCP_conn=%d time=%.3f ms\n", userInput.hostname, userInput.ip.String(), userInput.port, streak, rtt)
+				if userInput.hostname == userInput.ip.String() {
+					fmt.Printf("Reply from %s on port %d TCP_conn=%d time=%.3f ms\n", userInput.hostname, userInput.port, streak, rtt)
+				} else {
+					fmt.Printf("Reply from %s (%s) on port %d TCP_conn=%d time=%.3f ms\n", userInput.hostname, userInput.ip.String(), userInput.port, streak, rtt)
+				}
 			}
 		} else {
 			if userInput.showSourceAddress {
-				fmt.Printf("%s Reply from %s (%s) on port %d using %s TCP_conn=%d time=%.3f ms\n", timestamp, userInput.hostname, userInput.ip.String(), userInput.port, sourceAddr, streak, rtt)
+				if userInput.hostname == userInput.ip.String() {
+					fmt.Printf("%s Reply from %s on port %d using %s TCP_conn=%d time=%.3f ms\n", timestamp, userInput.hostname, userInput.port, sourceAddr, streak, rtt)
+				} else {
+					fmt.Printf("%s Reply from %s (%s) on port %d using %s TCP_conn=%d time=%.3f ms\n", timestamp, userInput.hostname, userInput.ip.String(), userInput.port, sourceAddr, streak, rtt)
+				}
 			} else {
-				fmt.Printf("%s Reply from %s (%s) on port %d TCP_conn=%d time=%.3f ms\n", timestamp, userInput.hostname, userInput.ip.String(), userInput.port, streak, rtt)
+				if userInput.hostname == userInput.ip.String() {
+					fmt.Printf("%s Reply from %s on port %d TCP_conn=%d time=%.3f ms\n", timestamp, userInput.hostname, userInput.port, streak, rtt)
+				} else {
+					fmt.Printf("%s Reply from %s (%s) on port %d TCP_conn=%d time=%.3f ms\n", timestamp, userInput.hostname, userInput.ip.String(), userInput.port, streak, rtt)
+				}
 			}
 		}
 	}

--- a/tcping.go
+++ b/tcping.go
@@ -19,7 +19,7 @@ import (
 	"github.com/google/go-github/v45/github"
 )
 
-var version = "" // set at compile time
+var version = "" // set at compile time through the Makefile
 
 const (
 	owner      = "pouriyajamshidi"
@@ -118,6 +118,7 @@ type userInput struct {
 	shouldRetryResolve       bool
 	showFailuresOnly         bool
 	showSourceAddress        bool
+	nonInteractive           bool // Enable the program to run in the background. e.g. nohup, disown
 }
 
 type genericUserInputArgs struct {
@@ -128,6 +129,7 @@ type genericUserInputArgs struct {
 	intName              *string
 	showFailuresOnly     *bool
 	showSourceAddress    *bool
+	nonInteractive       *bool
 	args                 []string
 }
 
@@ -361,6 +363,7 @@ func setGenericArgs(tcping *tcping, genericArgs genericUserInputArgs) {
 	tcping.userInput.showFailuresOnly = *genericArgs.showFailuresOnly
 
 	tcping.userInput.showSourceAddress = *genericArgs.showSourceAddress
+	tcping.userInput.nonInteractive = *genericArgs.nonInteractive
 }
 
 // processUserInput gets and validate user input
@@ -371,6 +374,7 @@ func processUserInput(tcping *tcping) {
 	probesBeforeQuit := flag.Uint("c", 0, "stop after <n> probes, regardless of the result. By default, no limit will be applied.")
 	outputJSON := flag.Bool("j", false, "output in JSON format.")
 	prettyJSON := flag.Bool("pretty", false, "use indentation when using json output format. No effect without the '-j' flag.")
+	nonInteractive := flag.Bool("non-interactive", false, "let tcping run in the background, for instance using nohup or disown")
 	noColor := flag.Bool("no-color", false, "do not colorize output.")
 	showTimestamp := flag.Bool("D", false, "show timestamp in output.")
 	saveToCSV := flag.String("csv", "", "path and file name to store tcping output to CSV file...If user prompts for stats, it will be saved to a file with the same name and _stats appended.")
@@ -414,7 +418,6 @@ func processUserInput(tcping *tcping) {
 	// host and port must be specified
 	// Support both "host port" and "host:port" formats
 	args = parseHostPortArgs(args)
-	
 	if len(args) != 2 {
 		usage()
 	}
@@ -434,6 +437,7 @@ func processUserInput(tcping *tcping) {
 		intName:              interfaceName,
 		showFailuresOnly:     showFailuresOnly,
 		showSourceAddress:    showSourceAddress,
+		nonInteractive:       nonInteractive,
 		args:                 args,
 	}
 
@@ -937,7 +941,9 @@ func main() {
 	tcping.printStart(tcping.userInput.hostname, tcping.userInput.port)
 
 	stdinchan := make(chan bool)
-	go monitorSTDIN(stdinchan)
+	if !tcping.userInput.nonInteractive {
+		go monitorSTDIN(stdinchan)
+	}
 
 	var probeCount uint
 	for {


### PR DESCRIPTION
# Summary


## v2.8.0 - 2026-05-11

- feat: add a _non-interactive_ mode through `--non-interactive` flag so that tcping can run in the background using `nohup` or `disown` - closes #391 
- feat: add support for `host:port` format in command arguments in [362](https://github.com/pouriyajamshidi/tcping/pull/362) thanks to @bingoohuang
- fix: omit printing the IP address twice when the given target is an IP address itself
- fix: add missing comma separator in no-color statistics output in [376](https://github.com/pouriyajamshidi/tcping/issues/376) thanks to @clarabennettdev
- fix: version typo resulting in erroneous update message raised in [313] (https://github.com/pouriyajamshidi/tcping/issues/313) - closes #313 
- build: bump Golang base image to `1.26.3-alpine3.23`
- documents: fix typo in the Chinese README in [386](https://github.com/pouriyajamshidi/tcping/pull/386) thanks to @peeweep
- documents: clarify the difference between static and dynamic binaries in README raised in [357](https://github.com/pouriyajamshidi/tcping/issues/357) - closes #357 
