### PR TITLE
Feat: Add mdev and jitter to final statistics

### DIFF
--- a/csv.go
+++ b/csv.go
@@ -321,9 +321,11 @@ func (cp *csvPrinter) printStatistics(t tcping) {
 
 	if t.rttResults.hasResults {
 		statistics = append(statistics,
+			[]string{"RTT Jitter", fmt.Sprintf("%.3f ms", t.rttResults.jitter)},
 			[]string{"RTT Min", fmt.Sprintf("%.3f ms", t.rttResults.min)},
 			[]string{"RTT Avg", fmt.Sprintf("%.3f ms", t.rttResults.average)},
 			[]string{"RTT Max", fmt.Sprintf("%.3f ms", t.rttResults.max)},
+			[]string{"RTT Mdev", fmt.Sprintf("%.3f ms", t.rttResults.mdev)},
 		)
 	}
 

--- a/db.go
+++ b/db.go
@@ -40,6 +40,8 @@ CREATE TABLE %s (
     latency_min REAL,
     latency_avg REAL,
     latency_max REAL,
+    latency_jitter REAL,
+    latency_mdev REAL,
 
 	total_duration TEXT,
     start_time DATETIME,
@@ -95,9 +97,11 @@ CREATE TABLE %s (
 	latency_min,
 	latency_avg,
 	latency_max,
+	latency_jitter,
+	latency_mdev,
 	start_time,
 	end_time,
-	total_duration) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);`
+	total_duration) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);`
 )
 
 // newDB creates a newDB with the given path and returns a pointer to the `database` struct
@@ -212,6 +216,8 @@ func (db *database) saveStats(tcping tcping) error {
 		fmt.Sprintf("%.3f", tcping.rttResults.min),
 		fmt.Sprintf("%.3f", tcping.rttResults.average),
 		fmt.Sprintf("%.3f", tcping.rttResults.max),
+		fmt.Sprintf("%.3f", tcping.rttResults.jitter),
+		fmt.Sprintf("%.3f", tcping.rttResults.mdev),
 		tcping.startTime.Format(timeFormat),
 		tcping.endTime.Format(timeFormat),
 		totalDuration,

--- a/db_test.go
+++ b/db_test.go
@@ -65,6 +65,8 @@ longest_downtime_end,
 latency_min,
 latency_avg,
 latency_max,
+latency_jitter,
+latency_mdev,
 start_time,
 end_time,
 total_duration
@@ -83,13 +85,13 @@ FROM ` + fmt.Sprintf("%s WHERE event_type = '%s'", db.tableName, eventTypeStatis
 		longestUptimeStart, longestUptimeEnd           string
 		longestDowntime                                string
 		longestDowntimeStart, longestDowntimeEnd       string
-		lMin, lAvg, lMax                               float32
+		lMin, lAvg, lMax, lJitter, lMdev               float32
 		startTimestamp, endTimestamp                   time.Time
 		totalDuration                                  string
 	)
 
 	resFunc := func(stmt *sqlite.Stmt) error {
-		Equals(t, stmt.ColumnCount(), 27)
+		Equals(t, stmt.ColumnCount(), 29)
 		var err error
 
 		// addr
@@ -142,14 +144,18 @@ FROM ` + fmt.Sprintf("%s WHERE event_type = '%s'", db.tableName, eventTypeStatis
 		lAvg = float32(stmt.ColumnFloat(22))
 		// latency_max
 		lMax = float32(stmt.ColumnFloat(23))
+		// latency_jitter
+		lJitter = float32(stmt.ColumnFloat(24))
+		// latency_mdev
+		lMdev = float32(stmt.ColumnFloat(25))
 		// start_time
-		startTimestamp, err = time.Parse(timeFormat, stmt.ColumnText(24))
+		startTimestamp, err = time.Parse(timeFormat, stmt.ColumnText(26))
 		isNil(t, err)
 		// end_time
-		endTimestamp, err = time.Parse(timeFormat, stmt.ColumnText(25))
+		endTimestamp, err = time.Parse(timeFormat, stmt.ColumnText(27))
 		isNil(t, err)
 		// total_duration
-		totalDuration = stmt.ColumnText(26)
+		totalDuration = stmt.ColumnText(28)
 		return nil
 	}
 
@@ -161,6 +167,8 @@ FROM ` + fmt.Sprintf("%s WHERE event_type = '%s'", db.tableName, eventTypeStatis
 	stat.rttResults.min = toFixedFloat(stat.rttResults.min, 3)
 	stat.rttResults.average = toFixedFloat(stat.rttResults.average, 3)
 	stat.rttResults.max = toFixedFloat(stat.rttResults.max, 3)
+	stat.rttResults.jitter = toFixedFloat(stat.rttResults.jitter, 3)
+	stat.rttResults.mdev = toFixedFloat(stat.rttResults.mdev, 3)
 
 	Equals(t, addr, stat.userInput.ip.String())
 	Equals(t, sourceAddr, "source address")
@@ -181,6 +189,8 @@ FROM ` + fmt.Sprintf("%s WHERE event_type = '%s'", db.tableName, eventTypeStatis
 	Equals(t, lMin, stat.rttResults.min)
 	Equals(t, lAvg, stat.rttResults.average)
 	Equals(t, lMax, stat.rttResults.max)
+	Equals(t, lJitter, stat.rttResults.jitter)
+	Equals(t, lMdev, stat.rttResults.mdev)
 	Equals(t, startTimestamp.Format(timeFormat), stat.startTime.Format(timeFormat))
 	Equals(t, endTimestamp.Format(timeFormat), stat.endTime.Format(timeFormat))
 
@@ -293,6 +303,9 @@ func mockStats() tcping {
 			min:     2.832,
 			average: 3.8123,
 			max:     4.0932,
+			jitter:  1.1234,
+			mdev:    0.4567,
+			hasResults: true,
 		},
 
 		hostnameChanges: hostNameChange(),

--- a/statsprinter.go
+++ b/statsprinter.go
@@ -142,16 +142,25 @@ func (p *colorPrinter) printStatistics(t tcping) {
 
 	if t.rttResults.hasResults {
 		colorYellow("rtt ")
+		colorLightCyan("jitter")
+		colorYellow(" (p95-p5): ")
+		colorLightCyan("%.3f", t.rttResults.jitter)
+		colorYellow(" ms\n")
+		colorYellow("rtt ")
 		colorGreen("min")
 		colorYellow("/")
 		colorCyan("avg")
 		colorYellow("/")
-		colorRed("max: ")
+		colorRed("max")
+		colorYellow("/")
+		colorLightBlue("mdev: ")
 		colorGreen("%.3f", t.rttResults.min)
 		colorYellow("/")
 		colorCyan("%.3f", t.rttResults.average)
 		colorYellow("/")
 		colorRed("%.3f", t.rttResults.max)
+		colorYellow("/")
+		colorLightBlue("%.3f", t.rttResults.mdev)
 		colorYellow(" ms\n")
 	}
 
@@ -351,8 +360,9 @@ func (p *plainPrinter) printStatistics(t tcping) {
 	}
 
 	if t.rttResults.hasResults {
-		fmt.Printf("rtt min/avg/max: ")
-		fmt.Printf("%.3f/%.3f/%.3f ms\n", t.rttResults.min, t.rttResults.average, t.rttResults.max)
+		fmt.Printf("rtt common band (p95-p5): %.3f ms\n", t.rttResults.jitter)
+		fmt.Printf("rtt min/avg/max/mdev: ")
+		fmt.Printf("%.3f/%.3f/%.3f/%.3f ms\n", t.rttResults.min, t.rttResults.average, t.rttResults.max, t.rttResults.mdev)
 	}
 
 	fmt.Printf("--------------------------------------\n")
@@ -536,6 +546,11 @@ type JSONData struct {
 	// Latency in ms for a successful probe messages.
 	Latency float32 `json:"latency,omitempty"`
 
+	// LatencyJitter is a latency stat for the stats event.
+	//
+	// It's a string on purpose, as we'd like to have exactly
+	// 3 decimal places without doing extra math.
+	LatencyJitter string `json:"latency_jitter,omitempty"`
 	// LatencyMin is a latency stat for the stats event.
 	//
 	// It's a string on purpose, as we'd like to have exactly
@@ -551,6 +566,11 @@ type JSONData struct {
 	// It's a string on purpose, as we'd like to have exactly
 	// 3 decimal places without doing extra math.
 	LatencyMax string `json:"latency_max,omitempty"`
+	// LatencyMdev is a latency stat for the stats event.
+	//
+	// It's a string on purpose, as we'd like to have exactly
+	// 3 decimal places without doing extra math.
+	LatencyMdev string `json:"latency_mdev,omitempty"`
 
 	// TotalDuration is a total amount of seconds that program was running.
 	//
@@ -726,9 +746,11 @@ func (p *jsonPrinter) printStatistics(t tcping) {
 	}
 
 	if t.rttResults.hasResults {
+		data.LatencyJitter = fmt.Sprintf("%.3f", t.rttResults.jitter)
 		data.LatencyMin = fmt.Sprintf("%.3f", t.rttResults.min)
 		data.LatencyAvg = fmt.Sprintf("%.3f", t.rttResults.average)
 		data.LatencyMax = fmt.Sprintf("%.3f", t.rttResults.max)
+		data.LatencyMdev = fmt.Sprintf("%.3f", t.rttResults.mdev)
 	}
 
 	if !t.endTime.IsZero() {

--- a/statsprinter.go
+++ b/statsprinter.go
@@ -27,6 +27,7 @@ var (
 	colorLightBlue   = color.FgLightBlue.Printf
 	colorLightGreen  = color.LightGreen.Printf
 	colorLightCyan   = color.LightCyan.Printf
+	colorMagenta     = color.Magenta.Printf
 )
 
 type colorPrinter struct {
@@ -143,24 +144,23 @@ func (p *colorPrinter) printStatistics(t tcping) {
 	if t.rttResults.hasResults {
 		colorYellow("rtt ")
 		colorLightCyan("jitter")
-		colorYellow(" (p95-p5): ")
+		colorYellow("/")
+		colorMagenta("mdev: ")
 		colorLightCyan("%.3f", t.rttResults.jitter)
+		colorYellow("/")
+		colorMagenta("%.3f", t.rttResults.mdev)
 		colorYellow(" ms\n")
 		colorYellow("rtt ")
 		colorGreen("min")
 		colorYellow("/")
 		colorCyan("avg")
 		colorYellow("/")
-		colorRed("max")
-		colorYellow("/")
-		colorLightBlue("mdev: ")
+		colorRed("max: ")
 		colorGreen("%.3f", t.rttResults.min)
 		colorYellow("/")
 		colorCyan("%.3f", t.rttResults.average)
 		colorYellow("/")
 		colorRed("%.3f", t.rttResults.max)
-		colorYellow("/")
-		colorLightBlue("%.3f", t.rttResults.mdev)
 		colorYellow(" ms\n")
 	}
 
@@ -360,9 +360,8 @@ func (p *plainPrinter) printStatistics(t tcping) {
 	}
 
 	if t.rttResults.hasResults {
-		fmt.Printf("rtt common band (p95-p5): %.3f ms\n", t.rttResults.jitter)
-		fmt.Printf("rtt min/avg/max/mdev: ")
-		fmt.Printf("%.3f/%.3f/%.3f/%.3f ms\n", t.rttResults.min, t.rttResults.average, t.rttResults.max, t.rttResults.mdev)
+		fmt.Printf("rtt jitter/mdev: %.3f/%.3f ms\n", t.rttResults.jitter, t.rttResults.mdev)
+		fmt.Printf("rtt min/avg/max: %.3f/%.3f/%.3f ms\n", t.rttResults.min, t.rttResults.average, t.rttResults.max)
 	}
 
 	fmt.Printf("--------------------------------------\n")

--- a/tcping.go
+++ b/tcping.go
@@ -770,13 +770,13 @@ func CalcMdev(rtts []float32) float32 {
 		return 0.0
 	}
 
-	var sum float32 = 0
+	var sum float32
 	for _, rtt := range rtts {
 		sum += rtt
 	}
 	mean := sum / float32(n)
 
-	var sumSquaredDiff float64 = 0
+	var sumSquaredDiff float64
 	for _, rtt := range rtts {
 		diff := float64(rtt - mean)
 		sumSquaredDiff += diff * diff

--- a/tcping.go
+++ b/tcping.go
@@ -763,7 +763,7 @@ func newLongestTime(startTime time.Time, duration time.Duration) longestTime {
 }
 
 // calcMdev calculates mean deviation from RTTs
-func CalcMdev(rtts []float32) float32 {
+func calcMdev(rtts []float32) float32 {
 	n := len(rtts)
 
 	if n < 2 {
@@ -840,7 +840,7 @@ func calcTimeStats(timeArr []float32) rttResult {
 		result.average = sum / float32(arrLen)
 	}
 	result.jitter = calcJitter(timeArr)
-	result.mdev = CalcMdev(timeArr)
+	result.mdev = calcMdev(timeArr)
 
 	return result
 }

--- a/tcping.go
+++ b/tcping.go
@@ -5,12 +5,14 @@ import (
 	"bufio"
 	"context"
 	"flag"
+	"math"
 	"math/rand"
 	"net"
 	"net/netip"
 	"os"
 	"os/signal"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"syscall"
@@ -149,6 +151,8 @@ type rttResult struct {
 	min        float32
 	max        float32
 	average    float32
+	mdev       float32
+	jitter     float32
 	hasResults bool
 }
 
@@ -191,7 +195,7 @@ func (t *tcping) printStats() {
 	} else {
 		calcLongestUptime(t, time.Since(t.startOfUptime))
 	}
-	t.rttResults = calcMinAvgMaxRttTime(t.rtt)
+	t.rttResults = calcTimeStats(t.rtt)
 
 	t.printStatistics(*t)
 }
@@ -758,8 +762,58 @@ func newLongestTime(startTime time.Time, duration time.Duration) longestTime {
 	}
 }
 
-// calcMinAvgMaxRttTime calculates min, avg and max RTT values
-func calcMinAvgMaxRttTime(timeArr []float32) rttResult {
+// calcMdev calculates mean deviation from RTTs
+func CalcMdev(rtts []float32) float32 {
+	n := len(rtts)
+
+	if n < 2 {
+		return 0.0
+	}
+
+	var sum float32 = 0
+	for _, rtt := range rtts {
+		sum += rtt
+	}
+	mean := sum / float32(n)
+
+	var sumSquaredDiff float64 = 0
+	for _, rtt := range rtts {
+		diff := float64(rtt - mean)
+		sumSquaredDiff += diff * diff
+	}
+
+	variance := sumSquaredDiff / float64(n)
+
+	mdev := math.Sqrt(variance)
+
+	return float32(mdev)
+}
+
+// calcJitter calculates jitter from RTTs, ignoring 5% highest and 5% lowest
+func calcJitter(timeArr []float32) float32 {
+	n := len(timeArr)
+
+	if n < 2 {
+		return 0.0
+	}
+
+	sortedRtts := make([]float32, n)
+	copy(sortedRtts, timeArr)
+
+	slices.Sort(sortedRtts)
+
+	p5Index := int(float32(n) * 0.05)
+	p95Index := int(float32(n) * 0.95)
+
+	if p95Index >= n {
+		p95Index = n - 1
+	}
+
+	return sortedRtts[p95Index] - sortedRtts[p5Index]
+}
+
+// calcTimeStats calculates min, avg, max and jitter RTT values
+func calcTimeStats(timeArr []float32) rttResult {
 	var sum float32
 	var result rttResult
 
@@ -785,6 +839,8 @@ func calcMinAvgMaxRttTime(timeArr []float32) rttResult {
 		result.hasResults = true
 		result.average = sum / float32(arrLen)
 	}
+	result.jitter = calcJitter(timeArr)
+	result.mdev = CalcMdev(timeArr)
 
 	return result
 }

--- a/tcping_test.go
+++ b/tcping_test.go
@@ -342,3 +342,88 @@ func TestSecondsToDuration(t *testing.T) {
 		})
 	}
 }
+
+func TestCalcMdev(t *testing.T) {
+	tests := []struct {
+		name string
+		rtts []float32
+		want float32
+	}{
+		{
+			name: "empty",
+			rtts: []float32{},
+			want: 0.0,
+		},
+		{
+			name: "single",
+			rtts: []float32{10.0},
+			want: 0.0,
+		},
+		{
+			name: "two identical",
+			rtts: []float32{10.0, 10.0},
+			want: 0.0,
+		},
+		{
+			name: "simple sequence",
+			rtts: []float32{10.0, 20.0, 30.0},
+			// mean = 20
+			// variance = ((10-20)^2 + (20-20)^2 + (30-20)^2) / 3 = (100 + 0 + 100) / 3 = 200/3 = 66.666
+			// sqrt(66.666) ≈ 8.1649658
+			want: 8.1649658,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := calcMdev(tt.rtts)
+			assert.InDelta(t, tt.want, got, 0.001)
+		})
+	}
+}
+
+func TestCalcJitter(t *testing.T) {
+	tests := []struct {
+		name string
+		rtts []float32
+		want float32
+	}{
+		{
+			name: "empty",
+			rtts: []float32{},
+			want: 0.0,
+		},
+		{
+			name: "single",
+			rtts: []float32{10.0},
+			want: 0.0,
+		},
+		{
+			name: "10 elements",
+			// 5% of 10 is 0
+			// 95% of 10 is 9
+			// index 9 is 90, index 0 is 0 -> 90
+			rtts: []float32{0.0, 10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0, 90.0},
+			want: 90.0,
+		},
+		{
+			name: "100 elements",
+			// 1 to 100. sorted.
+			// 5% is index 5
+			// 95% is index 95
+			rtts: func() []float32 {
+				r := make([]float32, 100)
+				for i := 0; i < 100; i++ {
+					r[i] = float32(i)
+				}
+				return r
+			}(),
+			want: 90.0, // 95 - 5
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := calcJitter(tt.rtts)
+			assert.InDelta(t, tt.want, got, 0.001)
+		})
+	}
+}


### PR DESCRIPTION
# Important

Add jitter (mdev, like classical ping & common band) statistics to end results
Mdev added to get the same end statistics as the basic ping command
Common band (p95-p5) serves as a more modern and simple approach to measuring jitter

### Preview
<img width="1376" height="420" alt="image" src="https://github.com/user-attachments/assets/e990df11-3276-46de-b362-ca4850bb270e" />

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added tests.
- [x] I have run `make check` and there are no failures.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
